### PR TITLE
Add service-facade layer covering the Go SDK subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,168 @@
 
 PHP SDK for [Uspacy](https://uspacy.com) – a single workspace for managing key processes of your organization with a focus on results. Communication, collaboration and CRM. All-in-one.
 
+Built on [Saloon](https://docs.saloon.dev/) and designed to mirror the official
+[JS](https://github.com/Uspacy/uspacy-js-sdk) and [Go](https://github.com/Uspacy/uspacy-go-sdk) SDKs.
+See the [Uspacy API reference](https://uspacy.readme.io/reference/introduction) for endpoint details.
 
+## Requirements
+
+- PHP `^8.2`
+- Laravel `^11 || ^12 || ^13` (the SDK ships as a Laravel package)
+
+## Installation
+
+```bash
+composer require uspacy/uspacy-php-sdk
+```
+
+The service provider is auto-discovered. Publish the config if you want to tune retries:
+
+```bash
+php artisan vendor:publish --provider="Uspacy\SDK\UspacySDKServiceProvider"
+```
+
+## Quick start
+
+```php
+use Uspacy\SDK\Http\Client\UspacySDK;
+
+// Base URL is your portal host, e.g. https://<domain>.uspacy.ua
+$sdk = new UspacySDK('https://acme.uspacy.ua', $accessToken);
+
+// Every call returns a Saloon\Http\Response — use ->json(), ->dto(), ->status()
+$deals = $sdk->crm()->getDeals(['page' => 1, 'list' => 20])->json();
+```
+
+## Architecture
+
+The SDK exposes **service facades** on the connector, mirroring the JS SDK's
+`httpClient.client.get/post/...` design:
+
+- `UspacySDK` — the Saloon connector (auth, retries, base URL).
+- `HttpClient` — a thin verb-oriented wrapper (`get/post/patch/put/delete/postForm`).
+- Generic request classes (`GetRequest`, `PostRequest`, …) build the actual HTTP calls.
+- One `*Service` per domain, each owning its API namespace.
+
+Every service is reachable through an accessor on the connector:
+
+| Accessor | Service | Module |
+| --- | --- | --- |
+| `$sdk->crm()` | `CrmService` | `crm/v1` |
+| `$sdk->smartObjects()` | `SmartObjectsService` | `crm/v1` |
+| `$sdk->tasks()` | `TasksService` | `tasks/v1` |
+| `$sdk->activities()` | `ActivitiesService` | `activities/v1` |
+| `$sdk->users()` | `UsersService` | `company/v1` |
+| `$sdk->departments()` | `DepartmentsService` | `company/v1` |
+| `$sdk->groups()` | `GroupsService` | `groups/v1` |
+| `$sdk->comments()` | `CommentsService` | `comments/v1` |
+| `$sdk->newsFeed()` | `NewsFeedService` | `newsfeed/v1` |
+| `$sdk->emails()` | `EmailsService` | `email/v1` |
+| `$sdk->files()` | `FilesService` | `files/v1` |
+| `$sdk->messenger()` | `MessengerService` | `messenger/v1` |
+| `$sdk->settings()` | `SettingsService` | `settings/v1` |
+| `$sdk->auth()` | `AuthService` | `auth/v1` |
+
+## Examples
+
+### CRM
+
+```php
+// Entities
+$sdk->crm()->getEntityTypes();
+$sdk->crm()->getEntities('deals', ['page' => 1, 'list' => 50]);
+$sdk->crm()->getContacts(['q' => 'ada@example.com']);
+
+$sdk->crm()->createDeal(['title' => 'New deal', 'amount' => 1000]);
+$sdk->crm()->patchEntity('deals', 42, ['amount' => 1500]);
+$sdk->crm()->massEditEntities('deals', ['all' => true, 'settings' => [/* ... */]]);
+
+// Fields
+$sdk->crm()->getFields('deals');
+$sdk->crm()->createField('deals', ['name' => 'Priority', 'type' => 'list']);
+$sdk->crm()->deleteField('deals', 'priority');
+
+// Funnels & kanban stages
+$sdk->crm()->getFunnels('deals');
+$sdk->crm()->getFunnelStagesByFunnelId('deals', 3);
+$sdk->crm()->moveFunnelStage('deals', 42, 'stage-id', ['reason' => 'won']);
+
+// Products, calls, CRM tasks
+$sdk->crm()->createProduct(['name' => 'Widget', 'price' => 9.99]);
+$sdk->crm()->createCall(['direction' => 'inbound', 'phone' => '+380...']);
+$sdk->crm()->createTask(['title' => 'Follow up']);
+```
+
+### Tasks
+
+```php
+$sdk->tasks()->getTasks(['page' => 1]);
+$sdk->tasks()->createTask(['title' => 'Ship SDK', 'responsibleId' => 7]);
+$sdk->tasks()->patchTask(15, ['title' => 'Ship SDK v1']);
+$sdk->tasks()->markTaskReady(15);
+$sdk->tasks()->getKanbanStages(['groupId' => 3]);
+```
+
+### Users & departments
+
+```php
+$sdk->users()->getAllUsers();
+$sdk->users()->getUsers(['page' => 2, 'list' => 20]);
+$sdk->users()->patchUser(7, ['position' => 'CTO']);
+
+$sdk->departments()->getDepartments();
+$sdk->departments()->addUsers(4, [7, 8, 9]);
+```
+
+### Files (multipart upload)
+
+```php
+$sdk->files()->uploadFiles(
+    [['name' => 'contract.pdf', 'data' => file_get_contents('/path/contract.pdf')]],
+    entityType: 'deals',
+    entityId: '42',
+);
+
+$sdk->files()->getFileById(101);
+$sdk->files()->deleteFilesByEntity('deals', 42);
+```
+
+### Messenger
+
+```php
+$sdk->messenger()->getExternalLines();
+$sdk->messenger()->createMessage(['chatId' => 1, 'text' => 'Hello']);
+$sdk->messenger()->goToMessage('message-id');
+```
+
+### Auth
+
+```php
+$tokens = $sdk->auth()->applicationSignIn($clientId, $clientSecret); // Tokens DTO
+$sdk->auth()->refreshToken();
+```
+
+## Error handling
+
+The connector uses Saloon's `AlwaysThrowOnErrors`, so non-2xx responses throw a
+`Saloon\Exceptions\Request\RequestException`. Message creation additionally throws
+`Uspacy\SDK\Exceptions\MessageDuplicationException` on duplicate-key errors.
+
+```php
+use Saloon\Exceptions\Request\RequestException;
+
+try {
+    $sdk->crm()->createDeal(['title' => 'New']);
+} catch (RequestException $e) {
+    $status = $e->getResponse()->status();
+    $body = $e->getResponse()->json();
+}
+```
+
+## Development
+
+```bash
+composer install
+composer check-cs   # code style (ECS, PSR-12 + clean-code)
+composer fix-cs     # auto-fix style
+```

--- a/src/Http/Client/HttpClient.php
+++ b/src/Http/Client/HttpClient.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\Requests\DeleteRequest;
+use Uspacy\SDK\Http\Client\Requests\FormPostRequest;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PatchRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Http\Client\Requests\PutRequest;
+
+/**
+ * Thin, verb-oriented wrapper around the Saloon connector.
+ *
+ * This is the PHP counterpart of the JS SDK's generic `HttpClient` (axios instance):
+ * services build an endpoint namespace and delegate the actual transport here.
+ */
+class HttpClient
+{
+    public function __construct(
+        private UspacySDK $connector,
+    ) {
+    }
+
+    public function get(string $endpoint, array $query = []): Response
+    {
+        return $this->connector->send(new GetRequest($endpoint, $query));
+    }
+
+    public function post(string $endpoint, array $payload = [], array $query = []): Response
+    {
+        return $this->connector->send(new PostRequest($endpoint, $payload, $query));
+    }
+
+    public function patch(string $endpoint, array $payload = [], array $query = []): Response
+    {
+        return $this->connector->send(new PatchRequest($endpoint, $payload, $query));
+    }
+
+    public function put(string $endpoint, array $payload = [], array $query = []): Response
+    {
+        return $this->connector->send(new PutRequest($endpoint, $payload, $query));
+    }
+
+    public function delete(string $endpoint, array $payload = [], array $query = []): Response
+    {
+        return $this->connector->send(new DeleteRequest($endpoint, $payload, $query));
+    }
+
+    public function postForm(string $endpoint, array $payload = []): Response
+    {
+        return $this->connector->send(new FormPostRequest($endpoint, $payload));
+    }
+
+    public function patchForm(string $endpoint, array $payload = []): Response
+    {
+        return $this->connector->send(new FormPostRequest($endpoint, $payload, Method::PATCH));
+    }
+
+    public function connector(): UspacySDK
+    {
+        return $this->connector;
+    }
+}

--- a/src/Http/Client/Requests/DeleteRequest.php
+++ b/src/Http/Client/Requests/DeleteRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Generic DELETE request, optionally carrying a JSON body.
+ */
+class DeleteRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $payload = [],
+        protected array $queryParams = [],
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->payload;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return \array_filter($this->queryParams, static fn ($value) => $value !== null);
+    }
+}

--- a/src/Http/Client/Requests/FormPostRequest.php
+++ b/src/Http/Client/Requests/FormPostRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasFormBody;
+
+/**
+ * Generic POST request with an `application/x-www-form-urlencoded` body.
+ *
+ * Used by endpoints that expect form-encoded payloads (groups, newsfeed, tasks),
+ * mirroring the Go SDK's `doPostEncodedForm`.
+ */
+class FormPostRequest extends Request implements HasBody
+{
+    use HasFormBody;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $payload = [],
+        protected Method $httpMethod = Method::POST,
+    ) {
+        $this->method = $httpMethod;
+    }
+
+    protected Method $method = Method::POST;
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Http/Client/Requests/FormPostRequest.php
+++ b/src/Http/Client/Requests/FormPostRequest.php
@@ -17,15 +17,15 @@ class FormPostRequest extends Request implements HasBody
 {
     use HasFormBody;
 
+    protected Method $method = Method::POST;
+
     public function __construct(
         protected string $endpoint,
         protected array $payload = [],
-        protected Method $httpMethod = Method::POST,
+        Method $httpMethod = Method::POST,
     ) {
         $this->method = $httpMethod;
     }
-
-    protected Method $method = Method::POST;
 
     public function resolveEndpoint(): string
     {

--- a/src/Http/Client/Requests/GetRequest.php
+++ b/src/Http/Client/Requests/GetRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * Generic GET request.
+ *
+ * Mirrors the JS SDK's `httpClient.client.get(namespace, { params })` call.
+ */
+class GetRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $queryParams = [],
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return \array_filter($this->queryParams, static fn ($value) => $value !== null);
+    }
+}

--- a/src/Http/Client/Requests/PatchRequest.php
+++ b/src/Http/Client/Requests/PatchRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Generic PATCH request with a JSON body.
+ */
+class PatchRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::PATCH;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $payload = [],
+        protected array $queryParams = [],
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->payload;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return \array_filter($this->queryParams, static fn ($value) => $value !== null);
+    }
+}

--- a/src/Http/Client/Requests/PostRequest.php
+++ b/src/Http/Client/Requests/PostRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Generic POST request with a JSON body.
+ *
+ * Mirrors the JS SDK's `httpClient.client.post(namespace, body, { params })` call.
+ */
+class PostRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $payload = [],
+        protected array $queryParams = [],
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->payload;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return \array_filter($this->queryParams, static fn ($value) => $value !== null);
+    }
+}

--- a/src/Http/Client/Requests/PutRequest.php
+++ b/src/Http/Client/Requests/PutRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Uspacy\SDK\Http\Client\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Generic PUT request with a JSON body.
+ */
+class PutRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::PUT;
+
+    public function __construct(
+        protected string $endpoint,
+        protected array $payload = [],
+        protected array $queryParams = [],
+    ) {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->payload;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return \array_filter($this->queryParams, static fn ($value) => $value !== null);
+    }
+}

--- a/src/Http/Client/UspacySDK.php
+++ b/src/Http/Client/UspacySDK.php
@@ -6,11 +6,27 @@ use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
+use Uspacy\SDK\Services\ActivitiesService;
+use Uspacy\SDK\Services\AuthService;
+use Uspacy\SDK\Services\CommentsService;
+use Uspacy\SDK\Services\CrmService;
+use Uspacy\SDK\Services\DepartmentsService;
+use Uspacy\SDK\Services\EmailsService;
+use Uspacy\SDK\Services\FilesService;
+use Uspacy\SDK\Services\GroupsService;
+use Uspacy\SDK\Services\MessengerService;
+use Uspacy\SDK\Services\NewsFeedService;
+use Uspacy\SDK\Services\SettingsService;
+use Uspacy\SDK\Services\SmartObjectsService;
+use Uspacy\SDK\Services\TasksService;
+use Uspacy\SDK\Services\UsersService;
 
 class UspacySDK extends Connector
 {
     use AcceptsJson;
     use AlwaysThrowOnErrors;
+
+    private ?HttpClient $httpClient = null;
 
     public function __construct(
         protected string $apiUrl,
@@ -23,6 +39,84 @@ class UspacySDK extends Connector
     public function resolveBaseUrl(): string
     {
         return $this->apiUrl;
+    }
+
+    /**
+     * Shared, verb-oriented HTTP client used by every service facade.
+     */
+    public function http(): HttpClient
+    {
+        return $this->httpClient ??= new HttpClient($this);
+    }
+
+    public function crm(): CrmService
+    {
+        return new CrmService($this->http());
+    }
+
+    public function smartObjects(): SmartObjectsService
+    {
+        return new SmartObjectsService($this->http());
+    }
+
+    public function tasks(): TasksService
+    {
+        return new TasksService($this->http());
+    }
+
+    public function activities(): ActivitiesService
+    {
+        return new ActivitiesService($this->http());
+    }
+
+    public function users(): UsersService
+    {
+        return new UsersService($this->http());
+    }
+
+    public function departments(): DepartmentsService
+    {
+        return new DepartmentsService($this->http());
+    }
+
+    public function groups(): GroupsService
+    {
+        return new GroupsService($this->http());
+    }
+
+    public function comments(): CommentsService
+    {
+        return new CommentsService($this->http());
+    }
+
+    public function newsFeed(): NewsFeedService
+    {
+        return new NewsFeedService($this->http());
+    }
+
+    public function emails(): EmailsService
+    {
+        return new EmailsService($this->http());
+    }
+
+    public function files(): FilesService
+    {
+        return new FilesService($this->http());
+    }
+
+    public function messenger(): MessengerService
+    {
+        return new MessengerService($this->http());
+    }
+
+    public function settings(): SettingsService
+    {
+        return new SettingsService($this->http());
+    }
+
+    public function auth(): AuthService
+    {
+        return new AuthService($this->http());
     }
 
     private function initRetryConfig(): void

--- a/src/Services/ActivitiesService.php
+++ b/src/Services/ActivitiesService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Activities service.
+ *
+ * Covers the `activities/v1` module. Mirrors the Go SDK's `activities.go`.
+ */
+class ActivitiesService extends Service
+{
+    private const NAMESPACE = '/activities/v1';
+
+    /**
+     * Get a page of activities.
+     *
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getActivities(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/activities', $params);
+    }
+
+    /**
+     * Create an activity.
+     */
+    public function createActivity(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/activities', $data);
+    }
+
+    /**
+     * Get a single activity by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getActivity($id, array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$id}", $params);
+    }
+
+    /**
+     * Update an activity.
+     *
+     * @param  int|string  $id
+     */
+    public function patchActivity($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/entities/{$id}", $data);
+    }
+
+    /**
+     * Delete an activity.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteActivity($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/entities/{$id}");
+    }
+
+    /**
+     * Mass delete activities.
+     */
+    public function massDeleteActivities(array $data): Response
+    {
+        return $this->http->delete(self::NAMESPACE . '/entities/mass_deletion', $data);
+    }
+}

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\Requests\Auth\ApplicationSignInRequest;
+use Uspacy\SDK\Http\Client\Requests\Auth\RefreshTokenRequest;
+use Uspacy\SDK\Http\Client\Requests\Auth\Tokens;
+
+/**
+ * Auth service.
+ *
+ * Covers the `auth/v1` module: application sign-in and token refresh.
+ */
+class AuthService extends Service
+{
+    /**
+     * Sign in as an application and receive a fresh token pair.
+     */
+    public function applicationSignIn(string $clientId, string $clientSecret): Tokens
+    {
+        return $this->http->connector()
+            ->send(new ApplicationSignInRequest($clientId, $clientSecret))
+            ->dto();
+    }
+
+    /**
+     * Refresh the current access token.
+     */
+    public function refreshToken(): Response
+    {
+        return $this->http->connector()->send(new RefreshTokenRequest());
+    }
+}

--- a/src/Services/CommentsService.php
+++ b/src/Services/CommentsService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Comments service.
+ *
+ * Covers the `comments/v1` module. Mirrors the Go SDK's `comments.go`.
+ */
+class CommentsService extends Service
+{
+    private const NAMESPACE = '/comments/v1';
+
+    /**
+     * Create a comment.
+     */
+    public function createComment(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/comments/', $data);
+    }
+}

--- a/src/Services/CrmService.php
+++ b/src/Services/CrmService.php
@@ -105,7 +105,7 @@ class CrmService extends Service
      */
     public function getFields(string $entityType): Response
     {
-        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/");
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields");
     }
 
     /**
@@ -113,7 +113,7 @@ class CrmService extends Service
      */
     public function getField(string $entityType, string $fieldType): Response
     {
-        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldType}/");
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldType}");
     }
 
     /**
@@ -129,7 +129,7 @@ class CrmService extends Service
      */
     public function deleteField(string $entityType, string $fieldCode): Response
     {
-        return $this->http->delete(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldCode}/");
+        return $this->http->delete(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldCode}");
     }
 
     /**

--- a/src/Services/CrmService.php
+++ b/src/Services/CrmService.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM service.
+ *
+ * Covers the `crm/v1` module: entities, the built-in contacts/companies/leads/deals
+ * entity types, fields, funnels, kanban stages, list values, fail reasons, calls,
+ * products and CRM tasks. Mirrors the Go SDK's `crm.go`/`product.go` surface.
+ */
+class CrmService extends Service
+{
+    private const NAMESPACE = '/crm/v1';
+
+    /**
+     * Get the list of available CRM entity definitions.
+     */
+    public function getEntityTypes(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/entity');
+    }
+
+    /**
+     * Get a page of entities of the given type.
+     *
+     * @param  string  $entityType  e.g. contacts, companies, leads, deals or a custom type
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getEntities(string $entityType, array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/", $params);
+    }
+
+    public function getContacts(array $params = []): Response
+    {
+        return $this->getEntities('contacts', $params);
+    }
+
+    public function getCompanies(array $params = []): Response
+    {
+        return $this->getEntities('companies', $params);
+    }
+
+    public function getLeads(array $params = []): Response
+    {
+        return $this->getEntities('leads', $params);
+    }
+
+    public function getDeals(array $params = []): Response
+    {
+        return $this->getEntities('deals', $params);
+    }
+
+    /**
+     * Create an entity of the given type.
+     */
+    public function createEntity(string $entityType, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/", $data);
+    }
+
+    public function createContact(array $data): Response
+    {
+        return $this->createEntity('contacts', $data);
+    }
+
+    public function createCompany(array $data): Response
+    {
+        return $this->createEntity('companies', $data);
+    }
+
+    public function createLead(array $data): Response
+    {
+        return $this->createEntity('leads', $data);
+    }
+
+    public function createDeal(array $data): Response
+    {
+        return $this->createEntity('deals', $data);
+    }
+
+    /**
+     * Partially update a single entity.
+     *
+     * @param  int|string  $id
+     */
+    public function patchEntity(string $entityType, $id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/entities/{$entityType}/{$id}", $data);
+    }
+
+    /**
+     * Mass edit entities of the given type.
+     */
+    public function massEditEntities(string $entityType, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/entities/{$entityType}/mass_edit", $data);
+    }
+
+    /**
+     * Get all fields for an entity type.
+     */
+    public function getFields(string $entityType): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/");
+    }
+
+    /**
+     * Get a single field definition by its type/code.
+     */
+    public function getField(string $entityType, string $fieldType): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldType}/");
+    }
+
+    /**
+     * Create a field for an entity type.
+     */
+    public function createField(string $entityType, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/fields", $data);
+    }
+
+    /**
+     * Delete a field by its code.
+     */
+    public function deleteField(string $entityType, string $fieldCode): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldCode}/");
+    }
+
+    /**
+     * Get all funnels for an entity type.
+     */
+    public function getFunnels(string $entityType): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/funnel");
+    }
+
+    /**
+     * Create a funnel for an entity type.
+     */
+    public function createFunnel(string $entityType, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/funnel", $data);
+    }
+
+    /**
+     * Get all kanban stages for an entity type.
+     */
+    public function getFunnelStages(string $entityType): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/kanban/stage/");
+    }
+
+    /**
+     * Get kanban stages for a specific funnel.
+     */
+    public function getFunnelStagesByFunnelId(string $entityType, int $funnelId): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/kanban/stage/", ['funnel_id' => $funnelId]);
+    }
+
+    /**
+     * Create a kanban stage for an entity type.
+     */
+    public function createFunnelStage(string $entityType, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/kanban/stage/", $data);
+    }
+
+    /**
+     * Update a kanban stage.
+     *
+     * @param  int|string  $stageId
+     */
+    public function patchFunnelStage(string $entityType, $stageId, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/entities/{$entityType}/kanban/stage/{$stageId}", $data);
+    }
+
+    /**
+     * Move an entity to another kanban stage.
+     *
+     * @param  int|string  $entityId
+     * @param  array  $reason  optional fail reason payload
+     */
+    public function moveFunnelStage(string $entityType, $entityId, string $stageId, array $reason = []): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/{$entityId}/move/stage/{$stageId}", $reason);
+    }
+
+    /**
+     * Get list (dropdown) values for a field.
+     */
+    public function getListValues(string $entityType, string $listName): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/lists/{$listName}");
+    }
+
+    /**
+     * Create a list (dropdown) value for a field.
+     */
+    public function createListValue(string $entityType, string $listName, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/lists/{$listName}", $data);
+    }
+
+    /**
+     * Create a fail reason for a kanban stage group.
+     *
+     * @param  int|string  $stageGroupId
+     */
+    public function createFailReason($stageGroupId, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/reasons/{$stageGroupId}", $data);
+    }
+
+    /**
+     * Register a call event.
+     */
+    public function createCall(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/events/call', $data);
+    }
+
+    /**
+     * Create a CRM task (static tasks entity).
+     */
+    public function createTask(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/static/tasks/', $data);
+    }
+
+    /**
+     * Update a CRM task.
+     *
+     * @param  int|string  $id
+     */
+    public function patchTask($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/static/tasks/{$id}", $data);
+    }
+
+    /**
+     * Get a product by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getProduct($id): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/static/products/{$id}");
+    }
+
+    /**
+     * Create a product.
+     */
+    public function createProduct(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/static/products/', $data);
+    }
+}

--- a/src/Services/DepartmentsService.php
+++ b/src/Services/DepartmentsService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Departments service.
+ *
+ * Covers departments under the `company/v1` module. Mirrors the Go SDK's `departments.go`.
+ */
+class DepartmentsService extends Service
+{
+    private const NAMESPACE = '/company/v1';
+
+    /**
+     * Get all departments.
+     */
+    public function getDepartments(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/departments/');
+    }
+
+    /**
+     * Create a department.
+     */
+    public function createDepartment(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/departments/', $data);
+    }
+
+    /**
+     * Update a department.
+     *
+     * @param  int|string  $departmentId
+     */
+    public function patchDepartment($departmentId, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/departments/{$departmentId}", $data);
+    }
+
+    /**
+     * Add users to a department.
+     *
+     * @param  int|string  $departmentId
+     * @param  array  $userIds  list of user ids
+     */
+    public function addUsers($departmentId, array $userIds): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/departments/{$departmentId}/addUsers", $userIds);
+    }
+}

--- a/src/Services/EmailsService.php
+++ b/src/Services/EmailsService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Emails service.
+ *
+ * Covers the `email/v1` module: folders, mailboxes and letters.
+ * Mirrors the Go SDK's `emails.go`.
+ */
+class EmailsService extends Service
+{
+    private const NAMESPACE = '/email/v1';
+
+    /**
+     * Get all mail folders.
+     */
+    public function getFolders(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/folders');
+    }
+
+    /**
+     * Create a mail folder.
+     */
+    public function createFolder(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/folders', $data);
+    }
+
+    /**
+     * Get all mailboxes.
+     */
+    public function getMailboxes(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/emails');
+    }
+
+    /**
+     * Create a letter inside a folder.
+     *
+     * @param  int|string  $folderId
+     */
+    public function createLetterByFolder($folderId, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/letters/by_folder/{$folderId}", $data);
+    }
+
+    /**
+     * Delete a letter by id.
+     *
+     * @param  int|string  $letterId
+     */
+    public function deleteLetter($letterId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/letters/{$letterId}");
+    }
+}

--- a/src/Services/FilesService.php
+++ b/src/Services/FilesService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\Requests\Files\UploadFilesRequest;
+
+/**
+ * Files service.
+ *
+ * Covers the `files/v1` module. Upload keeps the dedicated multipart request,
+ * the rest go through the generic HTTP client. Mirrors the Go SDK's `files.go`.
+ */
+class FilesService extends Service
+{
+    private const NAMESPACE = '/files/v1';
+
+    /**
+     * Get the list of files.
+     */
+    public function getFiles(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/files', $params);
+    }
+
+    /**
+     * Get a single file by id.
+     *
+     * @param  int|string  $fileId
+     */
+    public function getFileById($fileId): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/files/{$fileId}");
+    }
+
+    /**
+     * Upload one or more files and attach them to an entity.
+     *
+     * @param  array  $files  list of ['name' => filename, 'data' => contents|resource]
+     */
+    public function uploadFiles(array $files, string $entityType, string $entityId): Response
+    {
+        return $this->http->connector()->send(new UploadFilesRequest($files, $entityType, $entityId));
+    }
+
+    /**
+     * Delete a file by id.
+     *
+     * @param  int|string  $fileId
+     */
+    public function deleteFileById($fileId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/files/{$fileId}");
+    }
+
+    /**
+     * Delete all files attached to an entity.
+     *
+     * @param  int|string  $entityId
+     */
+    public function deleteFilesByEntity(string $entityType, $entityId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . '/files', [], [
+            'entityType' => $entityType,
+            'entityId' => $entityId,
+        ]);
+    }
+}

--- a/src/Services/GroupsService.php
+++ b/src/Services/GroupsService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Groups service.
+ *
+ * Covers the `groups/v1` module. Mirrors the Go SDK's `groups.go`.
+ */
+class GroupsService extends Service
+{
+    private const NAMESPACE = '/groups/v1';
+
+    /**
+     * Get a page of groups.
+     *
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getGroups(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/groups', $params);
+    }
+
+    /**
+     * Create a group (form-encoded payload).
+     */
+    public function createGroup(array $data): Response
+    {
+        return $this->http->postForm(self::NAMESPACE . '/groups', $data);
+    }
+
+    /**
+     * Transfer group ownership / membership.
+     */
+    public function transferGroup(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/transfer', $data);
+    }
+}

--- a/src/Services/MessengerService.php
+++ b/src/Services/MessengerService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Messages\UpdateMessageStatusDTO;
+use Uspacy\SDK\Http\Client\Requests\Messenger\CreateChatRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\CreateExternalLineRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\CreateMessageRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\DeleteMessageRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\GetExternalLineRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\GetExternalLinesRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\GetMessageRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\GoToMessageRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\UpdateExternalLineRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\UpdateMessageRequest;
+use Uspacy\SDK\Http\Client\Requests\Messenger\UpdateMessageStatusRequest;
+
+/**
+ * Messenger service.
+ *
+ * Facade over the dedicated `messenger/v1` request classes, which carry domain
+ * specific behaviour (e.g. duplicate-message detection on message creation).
+ */
+class MessengerService extends Service
+{
+    public function getExternalLines(): Response
+    {
+        return $this->http->connector()->send(new GetExternalLinesRequest());
+    }
+
+    public function getExternalLine(string $id): Response
+    {
+        return $this->http->connector()->send(new GetExternalLineRequest($id));
+    }
+
+    public function createExternalLine(array $payload): Response
+    {
+        return $this->http->connector()->send(new CreateExternalLineRequest($payload));
+    }
+
+    public function updateExternalLine(string $id, array $payload): Response
+    {
+        return $this->http->connector()->send(new UpdateExternalLineRequest($id, $payload));
+    }
+
+    public function createChat(array $payload): Response
+    {
+        return $this->http->connector()->send(new CreateChatRequest($payload));
+    }
+
+    public function createMessage(array $payload): Response
+    {
+        return $this->http->connector()->send(new CreateMessageRequest($payload));
+    }
+
+    public function getMessage(string $messageId): Response
+    {
+        return $this->http->connector()->send(new GetMessageRequest($messageId));
+    }
+
+    public function updateMessage(array $payload): Response
+    {
+        return $this->http->connector()->send(new UpdateMessageRequest($payload));
+    }
+
+    public function deleteMessage(string $messageId): Response
+    {
+        return $this->http->connector()->send(new DeleteMessageRequest($messageId));
+    }
+
+    public function goToMessage(string $messageId): Response
+    {
+        return $this->http->connector()->send(new GoToMessageRequest($messageId));
+    }
+
+    public function updateMessageStatus(string $messageId, UpdateMessageStatusDTO $payload): Response
+    {
+        return $this->http->connector()->send(new UpdateMessageStatusRequest($messageId, $payload));
+    }
+}

--- a/src/Services/NewsFeedService.php
+++ b/src/Services/NewsFeedService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * News feed service.
+ *
+ * Covers the `newsfeed/v1` module. Mirrors the Go SDK's `newsfeeds.go`.
+ */
+class NewsFeedService extends Service
+{
+    private const NAMESPACE = '/newsfeed/v1';
+
+    /**
+     * Get a page of news feed posts.
+     */
+    public function getPosts(int $page = 1, int $list = 20, int $groupId = 0): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/posts/', [
+            'page' => $page,
+            'list' => $list,
+            'group_id' => $groupId,
+        ]);
+    }
+
+    /**
+     * Create a news feed post (form-encoded payload).
+     */
+    public function createPost(array $data): Response
+    {
+        return $this->http->postForm(self::NAMESPACE . '/posts', $data);
+    }
+}

--- a/src/Services/NewsFeedService.php
+++ b/src/Services/NewsFeedService.php
@@ -16,7 +16,7 @@ class NewsFeedService extends Service
     /**
      * Get a page of news feed posts.
      */
-    public function getPosts(int $page = 1, int $list = 20, int $groupId = 0): Response
+    public function getPosts(int $page = 1, int $list = 20, ?int $groupId = null): Response
     {
         return $this->http->get(self::NAMESPACE . '/posts/', [
             'page' => $page,

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Uspacy\SDK\Http\Client\HttpClient;
+
+/**
+ * Base class for all domain services.
+ *
+ * Each service owns an API `namespace` (matching the JS SDK services) and issues
+ * requests through the shared {@see HttpClient}.
+ */
+abstract class Service
+{
+    public function __construct(
+        protected HttpClient $http,
+    ) {
+    }
+}

--- a/src/Services/SettingsService.php
+++ b/src/Services/SettingsService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\Requests\Settings\GetGeneralSettingsRequest;
+
+/**
+ * Settings service.
+ *
+ * Covers the `settings/v1` module.
+ */
+class SettingsService extends Service
+{
+    /**
+     * Get general portal settings for a domain.
+     */
+    public function getGeneralSettings(string $domain): Response
+    {
+        return $this->http->connector()->send(new GetGeneralSettingsRequest($domain));
+    }
+}

--- a/src/Services/SmartObjectsService.php
+++ b/src/Services/SmartObjectsService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Smart objects (custom CRM tables) service.
+ *
+ * Smart objects live under the `crm/v1` module. Mirrors the Go SDK's `smart-objects.go`.
+ */
+class SmartObjectsService extends Service
+{
+    private const NAMESPACE = '/crm/v1';
+
+    /**
+     * Create a new smart object (custom table definition).
+     */
+    public function createSmartObject(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/entity', $data);
+    }
+
+    /**
+     * Create an entity inside a smart object table.
+     */
+    public function createEntity(string $tableName, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$tableName}/", $data);
+    }
+
+    /**
+     * Get the fields of a smart object table.
+     */
+    public function getFields(string $tableName): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$tableName}/fields");
+    }
+
+    /**
+     * Create a field on a smart object table.
+     */
+    public function createField(string $tableName, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$tableName}/fields", $data);
+    }
+
+    /**
+     * Create a list (dropdown) value on a smart object field.
+     */
+    public function createListValue(string $tableName, string $listName, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$tableName}/lists/{$listName}", $data);
+    }
+
+    /**
+     * Get the kanban stages of a smart object table.
+     */
+    public function getStages(string $tableName): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/entities/{$tableName}/kanban/stage/");
+    }
+
+    /**
+     * Create a kanban stage on a smart object table.
+     */
+    public function createStage(string $tableName, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$tableName}/kanban/stage/", $data);
+    }
+
+    /**
+     * Move a smart object entity to another kanban stage.
+     *
+     * @param  int|string  $entityId
+     */
+    public function moveStage(string $tableName, $entityId, string $stageId, array $reason = []): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/entities/{$tableName}/{$entityId}/move/stage/{$stageId}", $reason);
+    }
+}

--- a/src/Services/TasksService.php
+++ b/src/Services/TasksService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Tasks service.
+ *
+ * Covers the `tasks/v1` module: tasks CRUD, kanban stages, custom fields and
+ * recurring templates. Mirrors the Go SDK's `tasks.go`.
+ */
+class TasksService extends Service
+{
+    private const NAMESPACE = '/tasks/v1';
+
+    /**
+     * Get a page of tasks.
+     *
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getTasks(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/tasks', $params);
+    }
+
+    /**
+     * Create a task.
+     */
+    public function createTask(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/tasks', $data);
+    }
+
+    /**
+     * Update a task.
+     *
+     * @param  int|string  $taskId
+     */
+    public function patchTask($taskId, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/tasks/{$taskId}", $data);
+    }
+
+    /**
+     * Mark a task as ready (completed).
+     *
+     * @param  int|string  $taskId
+     */
+    public function markTaskReady($taskId): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/tasks/{$taskId}/ready");
+    }
+
+    /**
+     * Transfer (reassign) tasks.
+     */
+    public function transferTasks(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/transfer', $data);
+    }
+
+    /**
+     * Get the custom fields available for tasks.
+     */
+    public function getTaskFields(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/custom_fields/tasks/fields');
+    }
+
+    /**
+     * Get the kanban stages for tasks.
+     *
+     * @param  array  $params  query parameters (e.g. groupId)
+     */
+    public function getKanbanStages(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/stages', $params);
+    }
+
+    /**
+     * Create a kanban stage.
+     */
+    public function createStage(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/stages', $data);
+    }
+
+    /**
+     * Delete a kanban stage.
+     *
+     * @param  int|string  $stageId
+     */
+    public function deleteStage($stageId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/stages/{$stageId}");
+    }
+
+    /**
+     * Get a recurring task template by id.
+     *
+     * @param  int|string  $templateId
+     */
+    public function getRecurringTemplate($templateId): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/templates/recurring/{$templateId}");
+    }
+}

--- a/src/Services/UsersService.php
+++ b/src/Services/UsersService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Users service.
+ *
+ * Covers user management under the `company/v1` module. Mirrors the Go SDK's `user.go`.
+ */
+class UsersService extends Service
+{
+    private const NAMESPACE = '/company/v1';
+
+    /**
+     * Get all users (including inactive), no pagination.
+     */
+    public function getAllUsers(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/users/', ['show' => 'all', 'list' => 'all']);
+    }
+
+    /**
+     * Get a page of users.
+     *
+     * @param  array  $params  query parameters (page, list, show, ...)
+     */
+    public function getUsers(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/users/', $params);
+    }
+
+    /**
+     * Get a single user by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getUserById($id): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/users/{$id}");
+    }
+
+    /**
+     * Update a user.
+     *
+     * @param  int|string  $id
+     */
+    public function patchUser($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/users/{$id}", $data);
+    }
+
+    /**
+     * Import/activate a registered user by email invite.
+     */
+    public function importRegisteredUser(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/invites/email/import_registered', $data);
+    }
+}


### PR DESCRIPTION
## Summary

Expands the PHP SDK from the existing Auth/Messenger/Files/Settings requests into a **service-oriented API** that mirrors the structure of the official [JS](https://github.com/Uspacy/uspacy-js-sdk) and [Go](https://github.com/Uspacy/uspacy-go-sdk) SDKs, using the [Uspacy API reference](https://uspacy.readme.io/reference/introduction) for endpoints.

Scope matches the **Go SDK subset**, with the **service-facade** architecture.

## What's new

**Generic HTTP layer** (the PHP counterpart of the JS SDK's generic `httpClient`):
- `GetRequest`, `PostRequest`, `PatchRequest`, `PutRequest`, `DeleteRequest`, `FormPostRequest` — Saloon request classes
- `HttpClient` — thin verb wrapper (`get/post/patch/put/delete/postForm`)
- `Services\Service` base class

**14 domain services** reachable via accessors on the connector:

| Accessor | Methods | Module |
| --- | --- | --- |
| `$sdk->crm()` | 32 | `crm/v1` |
| `$sdk->messenger()` | 11 | `messenger/v1` |
| `$sdk->tasks()` | 10 | `tasks/v1` |
| `$sdk->smartObjects()` | 8 | `crm/v1` |
| `$sdk->activities()` | 6 | `activities/v1` |
| `$sdk->files()` / `$sdk->users()` / `$sdk->emails()` | 5 each | `files/v1` · `company/v1` · `email/v1` |
| `$sdk->departments()` | 4 | `company/v1` |
| `$sdk->groups()` | 3 | `groups/v1` |
| `$sdk->newsFeed()` / `$sdk->auth()` | 2 each | `newsfeed/v1` · `auth/v1` |
| `$sdk->comments()` / `$sdk->settings()` | 1 each | `comments/v1` · `settings/v1` |

Endpoints mirror the Go SDK's URL constants. Existing bespoke requests (messenger duplicate-key handling, multipart file upload) are **preserved and wrapped**, not replaced.

## Usage

```php
$sdk = new UspacySDK('https://acme.uspacy.ua', $accessToken);

$sdk->crm()->getDeals(['page' => 1, 'list' => 20])->json();
$sdk->crm()->createContact(['first_name' => 'Ada']);
$sdk->tasks()->markTaskReady(15);
$sdk->users()->getAllUsers();
```

## Verification

- ✅ `php -l` on all files — zero syntax errors
- ✅ Reflection-checked wiring — all 14 accessors return correct service types
- ✅ Offline end-to-end request building — correct URLs, JSON + form bodies, query params attach, null params dropped, `Authorization: Bearer` header set
- ✅ `composer check-cs` (ECS / PSR-12 + clean-code) — clean

Also removed stale Laravel-app scaffolding cruft (bootstrap cache, storage logs, orphaned `config/saloon.php`, app `.env`).

## Follow-ups (not in this PR)

- PHPUnit/Pest test suite with mocked responses
- Optional typed DTOs per entity (currently methods return raw Saloon `Response`)
- Remaining JS-only services (Marketing, Automations, Analytics, Webhooks, Profile, Roles, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)