### PR TITLE
Add PHPUnit test suite for the service-facade SDK

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - ".github/**"
+
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ["8.2", "8.3", "8.4"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, intl
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Run test suite
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ try {
 
 ```bash
 composer install
+composer test       # run the PHPUnit suite (Saloon MockClient, no network)
 composer check-cs   # code style (ECS, PSR-12 + clean-code)
 composer fix-cs     # auto-fix style
 ```

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,15 @@
             "Uspacy\\SDK\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Uspacy\\SDK\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "check-cs": "vendor/bin/ecs check",
-        "fix-cs": "composer check-cs -- --fix"
+        "fix-cs": "composer check-cs -- --fix",
+        "test": "vendor/bin/phpunit"
     },
     "extra": {
         "laravel": {

--- a/ecs.php
+++ b/ecs.php
@@ -6,6 +6,7 @@ use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 return ECSConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
+        __DIR__ . '/tests',
     ])
     ->withSkip([
         __DIR__ . '/vendor',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Uspacy SDK Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Uspacy\SDK\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Uspacy\SDK\Http\Client\HttpClient;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Services;
+
+class ConnectorTest extends TestCase
+{
+    public function test_it_resolves_the_base_url(): void
+    {
+        $this->assertSame(self::BASE_URL, $this->sdk->resolveBaseUrl());
+    }
+
+    public function test_it_exposes_a_shared_http_client(): void
+    {
+        $this->assertInstanceOf(HttpClient::class, $this->sdk->http());
+        $this->assertSame($this->sdk->http(), $this->sdk->http(), 'http() should be memoised');
+    }
+
+    public function test_it_authenticates_with_a_bearer_token(): void
+    {
+        $pending = $this->sdk->createPendingRequest(new GetRequest('/crm/v1/entity'));
+
+        $this->assertSame('Bearer ' . self::TOKEN, $pending->headers()->get('Authorization'));
+    }
+
+    #[DataProvider('serviceAccessorProvider')]
+    public function test_service_accessors_return_the_expected_service(string $accessor, string $class): void
+    {
+        $this->assertInstanceOf($class, $this->sdk->{$accessor}());
+    }
+
+    public static function serviceAccessorProvider(): array
+    {
+        return [
+            ['crm', Services\CrmService::class],
+            ['smartObjects', Services\SmartObjectsService::class],
+            ['tasks', Services\TasksService::class],
+            ['activities', Services\ActivitiesService::class],
+            ['users', Services\UsersService::class],
+            ['departments', Services\DepartmentsService::class],
+            ['groups', Services\GroupsService::class],
+            ['comments', Services\CommentsService::class],
+            ['newsFeed', Services\NewsFeedService::class],
+            ['emails', Services\EmailsService::class],
+            ['files', Services\FilesService::class],
+            ['messenger', Services\MessengerService::class],
+            ['settings', Services\SettingsService::class],
+            ['auth', Services\AuthService::class],
+        ];
+    }
+}

--- a/tests/Http/GenericRequestsTest.php
+++ b/tests/Http/GenericRequestsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Http;
+
+use Saloon\Enums\Method;
+use Uspacy\SDK\Http\Client\Requests\FormPostRequest;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class GenericRequestsTest extends TestCase
+{
+    public function test_form_post_request_defaults_to_post(): void
+    {
+        $request = new FormPostRequest('/groups/v1/groups', ['title' => 'Sales']);
+
+        $this->assertSame(Method::POST, $request->getMethod());
+    }
+
+    public function test_form_post_request_honours_method_override(): void
+    {
+        $request = new FormPostRequest('/groups/v1/groups', ['title' => 'Sales'], Method::PATCH);
+
+        $this->assertSame(Method::PATCH, $request->getMethod());
+    }
+
+    public function test_get_request_drops_null_query_params(): void
+    {
+        $pending = $this->sdk->createPendingRequest(
+            new GetRequest('/crm/v1/entities/deals/', ['page' => 2, 'list' => null]),
+        );
+
+        $this->assertSame(['page' => 2], $pending->query()->all());
+    }
+
+    public function test_post_request_sends_json_body_and_query(): void
+    {
+        $pending = $this->sdk->createPendingRequest(
+            new PostRequest('/crm/v1/entities/deals/', ['title' => 'X'], ['dry' => 1]),
+        );
+
+        $this->assertSame(['title' => 'X'], $pending->body()->all());
+        $this->assertSame(['dry' => 1], $pending->query()->all());
+    }
+}

--- a/tests/Services/ActivitiesServiceTest.php
+++ b/tests/Services/ActivitiesServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class ActivitiesServiceTest extends TestCase
+{
+    public function test_get_activities(): void
+    {
+        $this->sdk->activities()->getActivities(['page' => 1]);
+
+        $this->assertRequestSent('GET', '/activities/v1/activities', null, ['page' => 1]);
+    }
+
+    public function test_create_activity(): void
+    {
+        $this->sdk->activities()->createActivity(['type' => 'call']);
+
+        $this->assertRequestSent('POST', '/activities/v1/activities', ['type' => 'call']);
+    }
+
+    public function test_get_activity_by_id_uses_entities_path(): void
+    {
+        $this->sdk->activities()->getActivity(12);
+
+        $this->assertRequestSent('GET', '/activities/v1/entities/12');
+    }
+
+    public function test_patch_activity(): void
+    {
+        $this->sdk->activities()->patchActivity(12, ['done' => true]);
+
+        $this->assertRequestSent('PATCH', '/activities/v1/entities/12', ['done' => true]);
+    }
+
+    public function test_delete_activity(): void
+    {
+        $this->sdk->activities()->deleteActivity(12);
+
+        $this->assertRequestSent('DELETE', '/activities/v1/entities/12');
+    }
+
+    public function test_mass_delete_activities_sends_body(): void
+    {
+        $this->sdk->activities()->massDeleteActivities(['ids' => [1, 2, 3]]);
+
+        $this->assertRequestSent('DELETE', '/activities/v1/entities/mass_deletion', ['ids' => [1, 2, 3]]);
+    }
+}

--- a/tests/Services/CrmServiceTest.php
+++ b/tests/Services/CrmServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmServiceTest extends TestCase
+{
+    public function test_get_entities_hits_the_typed_endpoint_with_query(): void
+    {
+        $this->sdk->crm()->getEntities('deals', ['page' => 2, 'list' => 20]);
+
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/', null, ['page' => 2, 'list' => 20]);
+    }
+
+    public function test_convenience_getters_map_to_builtin_types(): void
+    {
+        $this->sdk->crm()->getContacts();
+        $this->assertRequestSent('GET', '/crm/v1/entities/contacts/');
+
+        $this->sdk->crm()->getLeads();
+        $this->assertRequestSent('GET', '/crm/v1/entities/leads/');
+
+        $this->sdk->crm()->getDeals();
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/');
+    }
+
+    public function test_create_deal_posts_body_to_deals_endpoint(): void
+    {
+        $this->sdk->crm()->createDeal(['title' => 'New deal', 'amount' => 1000]);
+
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/', ['title' => 'New deal', 'amount' => 1000]);
+    }
+
+    public function test_patch_entity_targets_a_single_record(): void
+    {
+        $this->sdk->crm()->patchEntity('deals', 42, ['amount' => 1500]);
+
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/42', ['amount' => 1500]);
+    }
+
+    public function test_mass_edit_targets_the_mass_edit_endpoint(): void
+    {
+        $this->sdk->crm()->massEditEntities('deals', ['all' => true]);
+
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/mass_edit', ['all' => true]);
+    }
+
+    /**
+     * Regression: fields endpoints must NOT carry a trailing slash (PR review fix).
+     */
+    public function test_fields_endpoints_have_no_trailing_slash(): void
+    {
+        $this->sdk->crm()->getFields('deals');
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/fields');
+
+        $this->sdk->crm()->getField('deals', 'priority');
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/fields/priority');
+
+        $this->sdk->crm()->createField('deals', ['name' => 'Priority']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/fields', ['name' => 'Priority']);
+
+        $this->sdk->crm()->deleteField('deals', 'priority');
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/fields/priority');
+    }
+
+    public function test_funnel_stage_by_funnel_id_sends_query(): void
+    {
+        $this->sdk->crm()->getFunnelStagesByFunnelId('deals', 3);
+
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/kanban/stage/', null, ['funnel_id' => 3]);
+    }
+
+    public function test_move_funnel_stage_builds_the_move_endpoint(): void
+    {
+        $this->sdk->crm()->moveFunnelStage('deals', 42, 'stage-7', ['reason' => 'won']);
+
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/42/move/stage/stage-7', ['reason' => 'won']);
+    }
+
+    public function test_products_and_calls(): void
+    {
+        $this->sdk->crm()->getProduct(9);
+        $this->assertRequestSent('GET', '/crm/v1/static/products/9');
+
+        $this->sdk->crm()->createCall(['direction' => 'inbound']);
+        $this->assertRequestSent('POST', '/crm/v1/events/call', ['direction' => 'inbound']);
+    }
+}

--- a/tests/Services/FilesServiceTest.php
+++ b/tests/Services/FilesServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\Http\Client\Requests\Files\UploadFilesRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class FilesServiceTest extends TestCase
+{
+    public function test_get_files_with_params(): void
+    {
+        $this->sdk->files()->getFiles(['entityType' => 'deals']);
+
+        $this->assertRequestSent('GET', '/files/v1/files', null, ['entityType' => 'deals']);
+    }
+
+    public function test_get_file_by_id(): void
+    {
+        $this->sdk->files()->getFileById(101);
+
+        $this->assertRequestSent('GET', '/files/v1/files/101');
+    }
+
+    public function test_delete_file_by_id(): void
+    {
+        $this->sdk->files()->deleteFileById(101);
+
+        $this->assertRequestSent('DELETE', '/files/v1/files/101');
+    }
+
+    public function test_delete_files_by_entity_sends_query(): void
+    {
+        $this->sdk->files()->deleteFilesByEntity('deals', 42);
+
+        $this->assertRequestSent('DELETE', '/files/v1/files', null, ['entityType' => 'deals', 'entityId' => 42]);
+    }
+
+    public function test_upload_files_uses_multipart_request(): void
+    {
+        // Upload uses the dedicated multipart request, so give it its own mock.
+        $this->sdk->withMockClient(new MockClient([
+            UploadFilesRequest::class => MockResponse::make(['data' => []], 201),
+        ]));
+
+        $this->sdk->files()->uploadFiles(
+            [['name' => 'a.txt', 'data' => 'hello']],
+            'deals',
+            '42',
+        );
+
+        $this->sdk->getMockClient()->assertSent(UploadFilesRequest::class);
+    }
+}

--- a/tests/Services/NewsFeedServiceTest.php
+++ b/tests/Services/NewsFeedServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class NewsFeedServiceTest extends TestCase
+{
+    /**
+     * Regression: an unset group filter must be omitted, not sent as group_id=0 (PR review fix).
+     */
+    public function test_get_posts_omits_group_id_when_not_provided(): void
+    {
+        $this->sdk->newsFeed()->getPosts(page: 1, list: 20);
+
+        $this->assertRequestSent('GET', '/newsfeed/v1/posts/', null, ['page' => 1, 'list' => 20]);
+    }
+
+    public function test_get_posts_includes_group_id_when_provided(): void
+    {
+        $this->sdk->newsFeed()->getPosts(page: 1, list: 20, groupId: 5);
+
+        $this->assertRequestSent('GET', '/newsfeed/v1/posts/', null, ['page' => 1, 'list' => 20, 'group_id' => 5]);
+    }
+
+    public function test_create_post_is_form_encoded(): void
+    {
+        $this->sdk->newsFeed()->createPost(['message' => 'Hello']);
+
+        $this->assertRequestSent('POST', '/newsfeed/v1/posts', ['message' => 'Hello']);
+    }
+}

--- a/tests/Services/TasksServiceTest.php
+++ b/tests/Services/TasksServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class TasksServiceTest extends TestCase
+{
+    public function test_get_tasks_sends_query(): void
+    {
+        $this->sdk->tasks()->getTasks(['page' => 1]);
+
+        $this->assertRequestSent('GET', '/tasks/v1/tasks', null, ['page' => 1]);
+    }
+
+    public function test_create_task(): void
+    {
+        $this->sdk->tasks()->createTask(['title' => 'Ship SDK']);
+
+        $this->assertRequestSent('POST', '/tasks/v1/tasks', ['title' => 'Ship SDK']);
+    }
+
+    public function test_patch_task(): void
+    {
+        $this->sdk->tasks()->patchTask(15, ['title' => 'Ship v1']);
+
+        $this->assertRequestSent('PATCH', '/tasks/v1/tasks/15', ['title' => 'Ship v1']);
+    }
+
+    public function test_mark_task_ready_is_a_patch_to_ready_subresource(): void
+    {
+        $this->sdk->tasks()->markTaskReady(15);
+
+        $this->assertRequestSent('PATCH', '/tasks/v1/tasks/15/ready');
+    }
+
+    public function test_kanban_stages_with_group_filter(): void
+    {
+        $this->sdk->tasks()->getKanbanStages(['groupId' => 3]);
+
+        $this->assertRequestSent('GET', '/tasks/v1/stages', null, ['groupId' => 3]);
+    }
+
+    public function test_delete_stage(): void
+    {
+        $this->sdk->tasks()->deleteStage(8);
+
+        $this->assertRequestSent('DELETE', '/tasks/v1/stages/8');
+    }
+
+    public function test_task_custom_fields_endpoint(): void
+    {
+        $this->sdk->tasks()->getTaskFields();
+
+        $this->assertRequestSent('GET', '/tasks/v1/custom_fields/tasks/fields');
+    }
+}

--- a/tests/Services/UsersServiceTest.php
+++ b/tests/Services/UsersServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class UsersServiceTest extends TestCase
+{
+    public function test_get_all_users_requests_show_all_list_all(): void
+    {
+        $this->sdk->users()->getAllUsers();
+
+        $this->assertRequestSent('GET', '/company/v1/users/', null, ['show' => 'all', 'list' => 'all']);
+    }
+
+    public function test_get_users_paginated(): void
+    {
+        $this->sdk->users()->getUsers(['page' => 2, 'list' => 20]);
+
+        $this->assertRequestSent('GET', '/company/v1/users/', null, ['page' => 2, 'list' => 20]);
+    }
+
+    public function test_get_user_by_id(): void
+    {
+        $this->sdk->users()->getUserById(7);
+
+        $this->assertRequestSent('GET', '/company/v1/users/7');
+    }
+
+    public function test_patch_user(): void
+    {
+        $this->sdk->users()->patchUser(7, ['position' => 'CTO']);
+
+        $this->assertRequestSent('PATCH', '/company/v1/users/7', ['position' => 'CTO']);
+    }
+
+    public function test_import_registered_user(): void
+    {
+        $this->sdk->users()->importRegisteredUser(['email' => 'ada@example.com']);
+
+        $this->assertRequestSent('POST', '/company/v1/invites/email/import_registered', ['email' => 'ada@example.com']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Uspacy\SDK\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Request;
+use Uspacy\SDK\Http\Client\Requests\DeleteRequest;
+use Uspacy\SDK\Http\Client\Requests\FormPostRequest;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PatchRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Http\Client\Requests\PutRequest;
+use Uspacy\SDK\Http\Client\UspacySDK;
+use Uspacy\SDK\UspacySDKServiceProvider;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    protected const BASE_URL = 'https://acme.uspacy.ua';
+
+    protected const TOKEN = 'test-token';
+
+    protected UspacySDK $sdk;
+
+    protected MockClient $mock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sdk = new UspacySDK(self::BASE_URL, self::TOKEN);
+        $this->mock = $this->makeMockClient();
+        $this->sdk->withMockClient($this->mock);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [UspacySDKServiceProvider::class];
+    }
+
+    /**
+     * A mock client that returns a benign 200 response for every generic verb,
+     * so services can be exercised offline and their outgoing requests asserted.
+     */
+    protected function makeMockClient(): MockClient
+    {
+        $ok = MockResponse::make(['data' => [], 'meta' => []], 200);
+
+        return new MockClient([
+            GetRequest::class => $ok,
+            PostRequest::class => MockResponse::make(['id' => 1], 201),
+            PatchRequest::class => $ok,
+            PutRequest::class => $ok,
+            DeleteRequest::class => MockResponse::make([], 204),
+            FormPostRequest::class => MockResponse::make(['id' => 1], 201),
+        ]);
+    }
+
+    /**
+     * Assert that a request with the given method + endpoint (and optionally body/query) was sent.
+     *
+     * @param  array<string, mixed>|null  $body
+     * @param  array<string, mixed>|null  $query
+     */
+    protected function assertRequestSent(string $method, string $endpoint, ?array $body = null, ?array $query = null): void
+    {
+        $this->mock->assertSent(function (Request $request) use ($method, $endpoint, $body, $query): bool {
+            if ($request->getMethod()->value !== $method) {
+                return false;
+            }
+
+            if ($request->resolveEndpoint() !== $endpoint) {
+                return false;
+            }
+
+            if ($body !== null && (!$request instanceof HasBody || $request->body()->all() !== $body)) {
+                return false;
+            }
+
+            if ($query !== null && $request->query()->all() !== $query) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Adds a PHPUnit test suite for the service-facade layer merged in #87. Tests-only — no production code changes.

All tests run **offline** via Saloon's `MockClient`, so they're deterministic and CI-safe (no network, no credentials).

## Coverage

**56 tests, 64 assertions**, driven by an `assertRequestSent(method, endpoint, body?, query?)` helper on the base `TestCase` (Testbench):

| Test | Focus |
| --- | --- |
| `ConnectorTest` | All 14 service accessors return the right type, base URL, `Bearer` auth header, memoized `http()` |
| `CrmServiceTest` | Entities, convenience getters, create/patch/mass-edit, funnels & stages, products, calls |
| `TasksServiceTest` | Tasks CRUD, `markTaskReady` PATCH, stages, custom fields |
| `ActivitiesServiceTest` | Full CRUD + mass-deletion body |
| `UsersServiceTest` | `getAllUsers` query, pagination, patch, invite import |
| `FilesServiceTest` | Get/delete + multipart upload via the dedicated request |
| `NewsFeedServiceTest` | Posts + create |
| `GenericRequestsTest` | FormPostRequest method override, null-query dropping, JSON body+query |

### Regression tests for the #87 review fixes
- **Newsfeed `group_id`** omitted when null, present when set.
- **CRM fields endpoints** carry no trailing slash (`getFields`/`getField`/`deleteField`).

## Tooling

- `composer test` script + `autoload-dev` (`Uspacy\SDK\Tests\`)
- `phpunit.xml`
- ECS extended to scan `tests/`
- New **Tests** CI workflow — matrix across PHP **8.2 / 8.3 / 8.4**

## Verification

- ✅ `composer test` → OK (56 tests, 64 assertions), zero deprecations
- ✅ `composer check-cs` (ECS) → clean (src + tests)
- ✅ `composer validate --strict` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)