### PR TITLE
CRM completeness: dedicated CRM-family services (JS-parity, batch 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Dedicated, entity-scoped CRM services mirroring the JS SDK:
 
 | Accessor | Service | Scope |
 | --- | --- | --- |
-| `$sdk->crmDeals()` / `crmLeads()` / `crmContacts()` / `crmCompanies()` | `CrmEntityService` | `/crm/v1/entities/{type}` |
-| `$sdk->crmDealsFunnels()` / `crmLeadsFunnels()` | `CrmFunnelsService` | funnels, stages, reasons |
-| `$sdk->crmDealsStages()` / `crmLeadsStages()` | `CrmStagesService` | stages, reasons |
+| `$sdk->crmDeals()` / `$sdk->crmLeads()` / `$sdk->crmContacts()` / `$sdk->crmCompanies()` | `CrmEntityService` | `/crm/v1/entities/{type}` |
+| `$sdk->crmDealsFunnels()` / `$sdk->crmLeadsFunnels()` | `CrmFunnelsService` | funnels, stages, reasons |
+| `$sdk->crmDealsStages()` / `$sdk->crmLeadsStages()` | `CrmStagesService` | stages, reasons |
 | `$sdk->crmProducts()` | `CrmProductsService` | `/crm/v1/static/products` |
 | `$sdk->crmProductsCategories()` | `CrmProductsCategoryService` | `/crm/v1/static/product-categories` |
 | `$sdk->crmProductsUnits()` | `CrmProductsUnitService` | `/crm/v1/static/measurement-units` |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ Every service is reachable through an accessor on the connector:
 | `$sdk->settings()` | `SettingsService` | `settings/v1` |
 | `$sdk->auth()` | `AuthService` | `auth/v1` |
 
+### CRM-family services (JS-parity)
+
+Dedicated, entity-scoped CRM services mirroring the JS SDK:
+
+| Accessor | Service | Scope |
+| --- | --- | --- |
+| `$sdk->crmDeals()` / `crmLeads()` / `crmContacts()` / `crmCompanies()` | `CrmEntityService` | `/crm/v1/entities/{type}` |
+| `$sdk->crmDealsFunnels()` / `crmLeadsFunnels()` | `CrmFunnelsService` | funnels, stages, reasons |
+| `$sdk->crmDealsStages()` / `crmLeadsStages()` | `CrmStagesService` | stages, reasons |
+| `$sdk->crmProducts()` | `CrmProductsService` | `/crm/v1/static/products` |
+| `$sdk->crmProductsCategories()` | `CrmProductsCategoryService` | `/crm/v1/static/product-categories` |
+| `$sdk->crmProductsUnits()` | `CrmProductsUnitService` | `/crm/v1/static/measurement-units` |
+| `$sdk->crmProductsTaxes()` | `CrmProductsTaxesService` | `/crm/v1/static/taxes` |
+| `$sdk->crmProductsPriceTypes()` | `CrmProductsPriceTypesService` | `/crm/v1/static/product-price-types` |
+| `$sdk->crmProductsForEntity()` | `CrmProductsForEntityService` | `/crm/v1/static/list-products` |
+| `$sdk->crmRequisites()` | `CrmRequisitesService` | `/crm/v1/requisites` |
+| `$sdk->crmDocumentTemplates()` | `CrmDocumentTemplatesService` | `/crm/v1/documents/templates` |
+
 ## Examples
 
 ### CRM
@@ -87,6 +105,24 @@ $sdk->crm()->deleteField('deals', 'priority');
 $sdk->crm()->getFunnels('deals');
 $sdk->crm()->getFunnelStagesByFunnelId('deals', 3);
 $sdk->crm()->moveFunnelStage('deals', 42, 'stage-id', ['reason' => 'won']);
+
+// Entity-scoped CRM services (JS-parity)
+$sdk->crmDeals()->getEntities(['page' => 1]);
+$sdk->crmDeals()->createEntity(['title' => 'New deal']);
+$sdk->crmDeals()->massDeletion(entityIds: [1, 2, 3]);
+$sdk->crmDeals()->moveFromStageToStage(42, 9, reasonId: 3);
+
+$sdk->crmDealsFunnels()->getFunnels();
+$sdk->crmDealsStages()->getStages();
+
+// Products catalog
+$sdk->crmProducts()->getProducts(['page' => 1]);
+$sdk->crmProductsTaxes()->createProductTax(['name' => 'VAT', 'rate' => 20]);
+$sdk->crmProductsForEntity()->createProductsForEntity([['product_id' => 1, 'quantity' => 2]]);
+
+// Requisites & document templates
+$sdk->crmRequisites()->getCardRequisites(['entity_id' => 5]);
+$sdk->crmDocumentTemplates()->getDocumentTemplates();
 
 // Products, calls, CRM tasks
 $sdk->crm()->createProduct(['name' => 'Widget', 'price' => 9.99]);

--- a/src/Http/Client/UspacySDK.php
+++ b/src/Http/Client/UspacySDK.php
@@ -9,7 +9,18 @@ use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 use Uspacy\SDK\Services\ActivitiesService;
 use Uspacy\SDK\Services\AuthService;
 use Uspacy\SDK\Services\CommentsService;
+use Uspacy\SDK\Services\CrmDocumentTemplatesService;
+use Uspacy\SDK\Services\CrmEntityService;
+use Uspacy\SDK\Services\CrmFunnelsService;
+use Uspacy\SDK\Services\CrmProductsCategoryService;
+use Uspacy\SDK\Services\CrmProductsForEntityService;
+use Uspacy\SDK\Services\CrmProductsPriceTypesService;
+use Uspacy\SDK\Services\CrmProductsService;
+use Uspacy\SDK\Services\CrmProductsTaxesService;
+use Uspacy\SDK\Services\CrmProductsUnitService;
+use Uspacy\SDK\Services\CrmRequisitesService;
 use Uspacy\SDK\Services\CrmService;
+use Uspacy\SDK\Services\CrmStagesService;
 use Uspacy\SDK\Services\DepartmentsService;
 use Uspacy\SDK\Services\EmailsService;
 use Uspacy\SDK\Services\FilesService;
@@ -52,6 +63,86 @@ class UspacySDK extends Connector
     public function crm(): CrmService
     {
         return new CrmService($this->http());
+    }
+
+    public function crmDeals(): CrmEntityService
+    {
+        return new CrmEntityService($this->http(), 'deals');
+    }
+
+    public function crmLeads(): CrmEntityService
+    {
+        return new CrmEntityService($this->http(), 'leads');
+    }
+
+    public function crmContacts(): CrmEntityService
+    {
+        return new CrmEntityService($this->http(), 'contacts');
+    }
+
+    public function crmCompanies(): CrmEntityService
+    {
+        return new CrmEntityService($this->http(), 'companies');
+    }
+
+    public function crmDealsFunnels(): CrmFunnelsService
+    {
+        return new CrmFunnelsService($this->http(), 'deals');
+    }
+
+    public function crmLeadsFunnels(): CrmFunnelsService
+    {
+        return new CrmFunnelsService($this->http(), 'leads');
+    }
+
+    public function crmDealsStages(): CrmStagesService
+    {
+        return new CrmStagesService($this->http(), 'deals');
+    }
+
+    public function crmLeadsStages(): CrmStagesService
+    {
+        return new CrmStagesService($this->http(), 'leads');
+    }
+
+    public function crmProducts(): CrmProductsService
+    {
+        return new CrmProductsService($this->http());
+    }
+
+    public function crmProductsCategories(): CrmProductsCategoryService
+    {
+        return new CrmProductsCategoryService($this->http());
+    }
+
+    public function crmProductsUnits(): CrmProductsUnitService
+    {
+        return new CrmProductsUnitService($this->http());
+    }
+
+    public function crmProductsTaxes(): CrmProductsTaxesService
+    {
+        return new CrmProductsTaxesService($this->http());
+    }
+
+    public function crmProductsPriceTypes(): CrmProductsPriceTypesService
+    {
+        return new CrmProductsPriceTypesService($this->http());
+    }
+
+    public function crmProductsForEntity(): CrmProductsForEntityService
+    {
+        return new CrmProductsForEntityService($this->http());
+    }
+
+    public function crmRequisites(): CrmRequisitesService
+    {
+        return new CrmRequisitesService($this->http());
+    }
+
+    public function crmDocumentTemplates(): CrmDocumentTemplatesService
+    {
+        return new CrmDocumentTemplatesService($this->http());
     }
 
     public function smartObjects(): SmartObjectsService

--- a/src/Services/CrmDocumentTemplatesService.php
+++ b/src/Services/CrmDocumentTemplatesService.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM document templates service.
+ *
+ * Mirrors the JS SDK's CrmDocumentTemplatesService (`/crm/v1/documents/templates`).
+ */
+class CrmDocumentTemplatesService extends Service
+{
+    private const NAMESPACE = '/crm/v1/documents/templates';
+
+    /**
+     * Get document templates.
+     *
+     * @param  array  $params  filter params
+     */
+    public function getDocumentTemplates(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE, $params);
+    }
+
+    /**
+     * Get the fields available for document templates.
+     *
+     * @param  array  $params  filter params
+     */
+    public function getDocumentTemplatesFields(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/fields', $params);
+    }
+
+    /**
+     * Create a document template.
+     */
+    public function createTemplate(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a document template.
+     *
+     * @param  int|string  $id
+     */
+    public function updateTemplate($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a document template.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteTemplate($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Delete several document templates at once.
+     *
+     * @param  array  $ids  template ids
+     */
+    public function deleteArrayTemplates(array $ids): Response
+    {
+        return $this->http->delete(self::NAMESPACE, [], ['ids' => $ids]);
+    }
+}

--- a/src/Services/CrmEntityService.php
+++ b/src/Services/CrmEntityService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\HttpClient;
+
+/**
+ * CRM entity service scoped to a single built-in entity type
+ * (deals, leads, contacts, companies).
+ *
+ * Mirrors the JS SDK's per-entity services (CrmDealsService, CrmLeadsService,
+ * CrmContactsService, CrmCompaniesService), which are all the same surface bound
+ * to a different `/crm/v1/entities/{type}` namespace.
+ */
+class CrmEntityService extends Service
+{
+    public function __construct(
+        HttpClient $http,
+        private string $entityType,
+    ) {
+        parent::__construct($http);
+    }
+
+    /**
+     * Get a page of entities.
+     *
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getEntities(array $params = []): Response
+    {
+        return $this->http->get($this->namespace(), $params);
+    }
+
+    /**
+     * Create an entity.
+     */
+    public function createEntity(array $data): Response
+    {
+        return $this->http->post($this->namespace(), $data);
+    }
+
+    /**
+     * Update an entity.
+     *
+     * @param  int|string  $id
+     */
+    public function updateEntity($id, array $data): Response
+    {
+        return $this->http->patch($this->namespace() . "/{$id}", $data);
+    }
+
+    /**
+     * Delete an entity.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteEntity($id): Response
+    {
+        return $this->http->delete($this->namespace() . "/{$id}");
+    }
+
+    /**
+     * Mass delete entities.
+     *
+     * @param  array  $entityIds  ids to delete
+     * @param  array  $exceptIds  ids to exclude when $all is true
+     * @param  bool  $all  delete every entity matching $params
+     * @param  array  $params  query filters used when $all is true
+     */
+    public function massDeletion(array $entityIds = [], array $exceptIds = [], bool $all = false, array $params = []): Response
+    {
+        return $this->http->delete($this->namespace() . '/mass_deletion', [
+            'all' => $all,
+            'entity_ids' => $entityIds,
+            'except_ids' => $exceptIds,
+        ], $params);
+    }
+
+    /**
+     * Mass edit entities.
+     *
+     * @param  array  $payload  fields to apply
+     * @param  array  $settings  editing settings
+     * @param  array  $entityIds  ids to edit
+     * @param  array  $exceptIds  ids to exclude when $all is true
+     * @param  bool  $all  edit every entity matching $params
+     * @param  array  $params  query filters used when $all is true
+     */
+    public function massEditing(array $payload, array $settings = [], array $entityIds = [], array $exceptIds = [], bool $all = false, array $params = []): Response
+    {
+        return $this->http->patch($this->namespace() . '/mass_edit', [
+            'all' => $all,
+            'entity_ids' => $entityIds,
+            'except_ids' => $exceptIds,
+            'payload' => $payload,
+            'settings' => $settings,
+        ], $params);
+    }
+
+    /**
+     * Get the fields of this entity type.
+     */
+    public function getFields(): Response
+    {
+        return $this->http->get($this->namespace() . '/fields');
+    }
+
+    /**
+     * Create a field.
+     */
+    public function createField(array $data): Response
+    {
+        return $this->http->post($this->namespace() . '/fields', $data);
+    }
+
+    /**
+     * Update a field by its code.
+     */
+    public function updateField(string $code, array $data): Response
+    {
+        return $this->http->patch($this->namespace() . "/fields/{$code}", $data);
+    }
+
+    /**
+     * Delete a field by its code.
+     */
+    public function deleteField(string $code): Response
+    {
+        return $this->http->delete($this->namespace() . "/fields/{$code}");
+    }
+
+    /**
+     * Add/replace list (dropdown) values for a field.
+     *
+     * @param  array  $values  list values payload
+     */
+    public function updateListValues(string $fieldCode, array $values): Response
+    {
+        return $this->http->post($this->namespace() . "/lists/{$fieldCode}", $values);
+    }
+
+    /**
+     * Delete a single list (dropdown) value from a field.
+     */
+    public function deleteListValue(string $fieldCode, string $value): Response
+    {
+        return $this->http->delete($this->namespace() . "/lists/{$fieldCode}/{$value}");
+    }
+
+    /**
+     * Get entities that belong to a kanban stage.
+     *
+     * @param  int|string  $stageId
+     */
+    public function getByStage($stageId): Response
+    {
+        return $this->http->get($this->namespace() . "/kanban/stage/{$stageId}");
+    }
+
+    /**
+     * Move an entity from its current kanban stage to another.
+     *
+     * @param  int|string  $entityId
+     * @param  int|string  $stageId
+     * @param  int|string|null  $reasonId  fail reason id, when the target stage requires one
+     */
+    public function moveFromStageToStage($entityId, $stageId, $reasonId = null): Response
+    {
+        return $this->http->post(
+            $this->namespace() . "/{$entityId}/move/stage/{$stageId}",
+            ['reason_id' => $reasonId],
+        );
+    }
+
+    private function namespace(): string
+    {
+        return "/crm/v1/entities/{$this->entityType}";
+    }
+}

--- a/src/Services/CrmFunnelsService.php
+++ b/src/Services/CrmFunnelsService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\HttpClient;
+
+/**
+ * CRM funnels service scoped to a single entity type (deals, leads).
+ *
+ * Mirrors the JS SDK's CrmDealsFunnelsService / CrmLeadsFunnelsService: funnel
+ * CRUD, kanban stage CRUD and fail reasons managed per funnel.
+ */
+class CrmFunnelsService extends Service
+{
+    private const REASONS_NAMESPACE = '/crm/v1/reasons';
+
+    public function __construct(
+        HttpClient $http,
+        private string $entityType,
+    ) {
+        parent::__construct($http);
+    }
+
+    /**
+     * Get all funnels for this entity type.
+     */
+    public function getFunnels(): Response
+    {
+        return $this->http->get($this->namespace() . '/funnel');
+    }
+
+    /**
+     * Create a funnel.
+     */
+    public function createFunnel(array $data): Response
+    {
+        return $this->http->post($this->namespace() . '/funnel', $data);
+    }
+
+    /**
+     * Update a funnel.
+     *
+     * @param  int|string  $id
+     */
+    public function updateFunnel($id, array $data): Response
+    {
+        return $this->http->patch($this->namespace() . "/funnel/{$id}", $data);
+    }
+
+    /**
+     * Delete a funnel.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteFunnel($id): Response
+    {
+        return $this->http->delete($this->namespace() . "/funnel/{$id}");
+    }
+
+    /**
+     * Get the kanban stages of a specific funnel.
+     *
+     * @param  int|string  $funnelId
+     */
+    public function getStagesByFunnel($funnelId): Response
+    {
+        return $this->http->get($this->namespace() . '/kanban/stage', ['funnel_id' => $funnelId]);
+    }
+
+    /**
+     * Create a kanban stage for a funnel.
+     */
+    public function createStage(array $data): Response
+    {
+        return $this->http->post($this->namespace() . '/kanban/stage', $data);
+    }
+
+    /**
+     * Update a kanban stage.
+     *
+     * @param  int|string  $id
+     */
+    public function updateStage($id, array $data): Response
+    {
+        return $this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data);
+    }
+
+    /**
+     * Delete a kanban stage.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteStage($id): Response
+    {
+        return $this->http->delete($this->namespace() . "/kanban/stage/{$id}");
+    }
+
+    /**
+     * Create a fail reason for a funnel stage.
+     *
+     * @param  int|string  $funnelId
+     */
+    public function createStageReason($funnelId, array $data): Response
+    {
+        return $this->http->post(self::REASONS_NAMESPACE . "/{$funnelId}", $data);
+    }
+
+    /**
+     * Update a fail reason.
+     *
+     * @param  int|string  $id
+     */
+    public function updateStageReason($id, array $data): Response
+    {
+        return $this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a fail reason.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteStageReason($id): Response
+    {
+        return $this->http->delete(self::REASONS_NAMESPACE . "/{$id}");
+    }
+
+    private function namespace(): string
+    {
+        return "/crm/v1/entities/{$this->entityType}";
+    }
+}

--- a/src/Services/CrmProductsCategoryService.php
+++ b/src/Services/CrmProductsCategoryService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM product categories service.
+ *
+ * Mirrors the JS SDK's CrmProductsCategoryService (`/crm/v1/static/product-categories`).
+ */
+class CrmProductsCategoryService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/product-categories';
+
+    /**
+     * Get all product categories.
+     */
+    public function getProductCategories(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Create a product category.
+     */
+    public function createProductCategory(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a product category.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProductCategory($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a product category, moving its products to another category.
+     *
+     * @param  int|string  $id
+     * @param  int|string  $categoryForProducts  category the orphaned products are moved to
+     * @param  bool  $removeWithChild  also delete child categories
+     */
+    public function deleteProductCategory($id, $categoryForProducts, bool $removeWithChild = false): Response
+    {
+        $query = ['category_for_products' => $categoryForProducts];
+
+        if ($removeWithChild) {
+            $query['child_categories'] = 'delete';
+        }
+
+        return $this->http->delete(self::NAMESPACE . "/{$id}", [], $query);
+    }
+}

--- a/src/Services/CrmProductsForEntityService.php
+++ b/src/Services/CrmProductsForEntityService.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM "products for entity" service (line products attached to CRM records).
+ *
+ * Mirrors the JS SDK's CrmProductsForEntityService: line products live under
+ * `/crm/v1/static/list-products`, and their aggregated info under
+ * `/crm/v1/static/entity-product-lists`.
+ */
+class CrmProductsForEntityService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/list-products';
+
+    private const INFO_NAMESPACE = '/crm/v1/static/entity-product-lists';
+
+    /**
+     * Get aggregated product info attached to an entity.
+     *
+     * @param  int|string  $entityId
+     */
+    public function getInfoProductsForEntity(string $entityType, $entityId): Response
+    {
+        return $this->http->get(self::INFO_NAMESPACE, [
+            'entity_type' => $entityType,
+            'entity_id' => $entityId,
+        ]);
+    }
+
+    /**
+     * Update aggregated product info.
+     *
+     * @param  int|string  $id
+     */
+    public function updateInfoProductForEntity($id, array $info): Response
+    {
+        return $this->http->patch(self::INFO_NAMESPACE . "/{$id}", $info);
+    }
+
+    /**
+     * Get all line products.
+     */
+    public function getProductsForEntity(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Get a single line product.
+     *
+     * @param  int|string  $id
+     */
+    public function getProductForEntity($id): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Create a line product.
+     */
+    public function createProductForEntity(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a line product.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProductForEntity($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Bulk create line products.
+     *
+     * @param  array  $listProducts  list of line products
+     */
+    public function createProductsForEntity(array $listProducts): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/bulk', ['list_products' => $listProducts]);
+    }
+
+    /**
+     * Bulk update line products.
+     *
+     * @param  array  $listProducts  list of line products
+     */
+    public function updateProductsForEntity(array $listProducts): Response
+    {
+        return $this->http->patch(self::NAMESPACE . '/bulk', ['list_products' => $listProducts]);
+    }
+
+    /**
+     * Delete a line product.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteProductForEntity($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Bulk delete line products.
+     *
+     * @param  array  $ids  line product ids
+     */
+    public function deleteProductsForEntity(array $ids): Response
+    {
+        return $this->http->delete(self::NAMESPACE . '/bulk', [], ['list_products' => $ids]);
+    }
+}

--- a/src/Services/CrmProductsForEntityService.php
+++ b/src/Services/CrmProductsForEntityService.php
@@ -20,6 +20,7 @@ class CrmProductsForEntityService extends Service
     /**
      * Get aggregated product info attached to an entity.
      *
+     * @param  string  $entityType
      * @param  int|string  $entityId
      */
     public function getInfoProductsForEntity(string $entityType, $entityId): Response

--- a/src/Services/CrmProductsPriceTypesService.php
+++ b/src/Services/CrmProductsPriceTypesService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM product price types service.
+ *
+ * Mirrors the JS SDK's CrmProductsPriceTypesService (`/crm/v1/static/product-price-types`).
+ */
+class CrmProductsPriceTypesService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/product-price-types';
+
+    /**
+     * Get all price types.
+     */
+    public function getProductPriceTypes(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Create a price type.
+     */
+    public function createProductPriceType(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a price type.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProductPriceType($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a price type.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteProductPriceType($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+}

--- a/src/Services/CrmProductsService.php
+++ b/src/Services/CrmProductsService.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM products service.
+ *
+ * Mirrors the JS SDK's CrmProductsService: the products catalog lives under
+ * `/crm/v1/static/products`, while product fields/list-values are managed through
+ * the dynamic entity namespace `/crm/v1/entities/products`.
+ */
+class CrmProductsService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/products';
+
+    private const DYNAMIC_NAMESPACE = '/crm/v1/entities/products';
+
+    /**
+     * Get a page of products.
+     *
+     * @param  array  $params  query parameters (page, list, filters, ...)
+     */
+    public function getProducts(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE, $params);
+    }
+
+    /**
+     * Create a product.
+     */
+    public function createProduct(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a product.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProduct($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a product.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteProduct($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Mass delete products.
+     *
+     * @param  array  $params  query filters used when $all is true
+     */
+    public function massDeletion(array $entityIds = [], array $exceptIds = [], bool $all = false, array $params = []): Response
+    {
+        return $this->http->delete(self::NAMESPACE . '/mass_deletion', [
+            'all' => $all,
+            'entity_ids' => $entityIds,
+            'except_ids' => $exceptIds,
+        ], $params);
+    }
+
+    /**
+     * Mass edit products.
+     *
+     * @param  array  $params  query filters used when $all is true
+     */
+    public function massEditing(array $payload, array $settings = [], array $entityIds = [], array $exceptIds = [], bool $all = false, array $params = []): Response
+    {
+        return $this->http->patch(self::NAMESPACE . '/mass_edit', [
+            'all' => $all,
+            'entity_ids' => $entityIds,
+            'except_ids' => $exceptIds,
+            'payload' => $payload,
+            'settings' => $settings,
+        ], $params);
+    }
+
+    /**
+     * Get product fields.
+     */
+    public function getFields(): Response
+    {
+        return $this->http->get(self::DYNAMIC_NAMESPACE . '/fields');
+    }
+
+    /**
+     * Create a product field.
+     */
+    public function createField(array $data): Response
+    {
+        return $this->http->post(self::DYNAMIC_NAMESPACE . '/fields', $data);
+    }
+
+    /**
+     * Update a product field by its code.
+     */
+    public function updateField(string $code, array $data): Response
+    {
+        return $this->http->patch(self::DYNAMIC_NAMESPACE . "/fields/{$code}", $data);
+    }
+
+    /**
+     * Delete a product field by its code.
+     */
+    public function deleteField(string $code): Response
+    {
+        return $this->http->delete(self::DYNAMIC_NAMESPACE . "/fields/{$code}");
+    }
+
+    /**
+     * Add/replace list (dropdown) values for a product field.
+     */
+    public function updateListValues(string $fieldCode, array $values): Response
+    {
+        return $this->http->post(self::DYNAMIC_NAMESPACE . "/lists/{$fieldCode}", $values);
+    }
+
+    /**
+     * Delete a single list (dropdown) value from a product field.
+     */
+    public function deleteListValue(string $fieldCode, string $value): Response
+    {
+        return $this->http->delete(self::DYNAMIC_NAMESPACE . "/lists/{$fieldCode}/{$value}");
+    }
+}

--- a/src/Services/CrmProductsTaxesService.php
+++ b/src/Services/CrmProductsTaxesService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM product taxes service.
+ *
+ * Mirrors the JS SDK's CrmProductsTaxesService (`/crm/v1/static/taxes`).
+ */
+class CrmProductsTaxesService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/taxes';
+
+    /**
+     * Get all taxes.
+     */
+    public function getProductTaxes(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Create a tax.
+     */
+    public function createProductTax(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a tax.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProductTax($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a tax.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteProductTax($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+}

--- a/src/Services/CrmProductsUnitService.php
+++ b/src/Services/CrmProductsUnitService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM product measurement units service.
+ *
+ * Mirrors the JS SDK's CrmProductsUnitService (`/crm/v1/static/measurement-units`).
+ */
+class CrmProductsUnitService extends Service
+{
+    private const NAMESPACE = '/crm/v1/static/measurement-units';
+
+    /**
+     * Get all measurement units.
+     */
+    public function getProductUnits(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Create a measurement unit.
+     */
+    public function createProductUnit(array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data);
+    }
+
+    /**
+     * Update a measurement unit.
+     *
+     * @param  int|string  $id
+     */
+    public function updateProductUnit($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a measurement unit.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteProductUnit($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+}

--- a/src/Services/CrmRequisitesService.php
+++ b/src/Services/CrmRequisitesService.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * CRM requisites service.
+ *
+ * Mirrors the JS SDK's CrmRequisitesService (`/crm/v1/requisites`): requisite
+ * templates, card requisites, and their nested bank requisites.
+ */
+class CrmRequisitesService extends Service
+{
+    private const NAMESPACE = '/crm/v1/requisites';
+
+    /**
+     * Get requisite templates.
+     *
+     * @param  array  $params  pagination params (page, list)
+     */
+    public function getTemplates(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/templates', $params);
+    }
+
+    /**
+     * Get card requisites.
+     *
+     * @param  array  $params  requisite list filter params
+     */
+    public function getCardRequisites(array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE, $params);
+    }
+
+    /**
+     * Create a card requisite.
+     *
+     * @param  array  $params  requisite list filter params
+     */
+    public function createCardRequisites(array $data, array $params = []): Response
+    {
+        return $this->http->post(self::NAMESPACE, $data, $params);
+    }
+
+    /**
+     * Update a card requisite.
+     *
+     * @param  int|string  $id
+     */
+    public function updateCardRequisites($id, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Attach a card requisite reference.
+     *
+     * @param  array  $params  requisite list filter params
+     */
+    public function attachCardRequisites(array $params = []): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/references/attach-reference', [], $params);
+    }
+
+    /**
+     * Delete a card requisite.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteCardRequisites($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Create a bank requisite under a card requisite.
+     *
+     * @param  int|string  $requisiteId
+     */
+    public function createBankRequisites($requisiteId, array $data): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites", $data);
+    }
+
+    /**
+     * Update a bank requisite.
+     *
+     * @param  int|string  $requisiteId
+     * @param  int|string  $bankRequisiteId
+     */
+    public function updateBankRequisites($requisiteId, $bankRequisiteId, array $data): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$requisiteId}/bank_requisites/{$bankRequisiteId}", $data);
+    }
+
+    /**
+     * Delete a bank requisite.
+     *
+     * @param  int|string  $requisiteId
+     * @param  int|string  $bankRequisiteId
+     */
+    public function deleteBankRequisites($requisiteId, $bankRequisiteId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$requisiteId}/bank_requisites/{$bankRequisiteId}");
+    }
+
+    /**
+     * Attach a bank requisite reference.
+     *
+     * @param  int|string  $requisiteId
+     * @param  array  $params  requisite list filter params
+     */
+    public function attachBankRequisites($requisiteId, array $params = []): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites/references/attach-reference", [], $params);
+    }
+}

--- a/src/Services/CrmStagesService.php
+++ b/src/Services/CrmStagesService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+use Uspacy\SDK\Http\Client\HttpClient;
+
+/**
+ * CRM kanban stages service scoped to a single entity type (deals, leads).
+ *
+ * Mirrors the JS SDK's CrmDealsStagesService / CrmLeadsStagesService: stage CRUD
+ * and fail reasons managed per entity record.
+ */
+class CrmStagesService extends Service
+{
+    private const REASONS_NAMESPACE = '/crm/v1/reasons';
+
+    public function __construct(
+        HttpClient $http,
+        private string $entityType,
+    ) {
+        parent::__construct($http);
+    }
+
+    /**
+     * Get all kanban stages for this entity type.
+     */
+    public function getStages(): Response
+    {
+        return $this->http->get($this->namespace() . '/kanban/stage');
+    }
+
+    /**
+     * Create a kanban stage.
+     */
+    public function createStage(array $data): Response
+    {
+        return $this->http->post($this->namespace() . '/kanban/stage', $data);
+    }
+
+    /**
+     * Update a kanban stage.
+     *
+     * @param  int|string  $id
+     */
+    public function updateStage($id, array $data): Response
+    {
+        return $this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data);
+    }
+
+    /**
+     * Delete a kanban stage.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteStage($id): Response
+    {
+        return $this->http->delete($this->namespace() . "/kanban/stage/{$id}");
+    }
+
+    /**
+     * Get the fail reasons recorded for an entity record.
+     *
+     * @param  int|string  $entityId
+     */
+    public function getReasons($entityId): Response
+    {
+        return $this->http->get(self::REASONS_NAMESPACE . "/{$entityId}");
+    }
+
+    /**
+     * Create a fail reason for an entity record.
+     *
+     * @param  int|string  $entityId
+     */
+    public function createReason($entityId, array $data): Response
+    {
+        return $this->http->post(self::REASONS_NAMESPACE . "/{$entityId}", $data);
+    }
+
+    /**
+     * Update a fail reason.
+     *
+     * @param  int|string  $id
+     */
+    public function updateReason($id, array $data): Response
+    {
+        return $this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a fail reason.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteReason($id): Response
+    {
+        return $this->http->delete(self::REASONS_NAMESPACE . "/{$id}");
+    }
+
+    private function namespace(): string
+    {
+        return "/crm/v1/entities/{$this->entityType}";
+    }
+}

--- a/tests/Services/CrmEntityServiceTest.php
+++ b/tests/Services/CrmEntityServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmEntityServiceTest extends TestCase
+{
+    public function test_deals_and_leads_are_scoped_to_their_namespace(): void
+    {
+        $this->sdk->crmDeals()->getEntities(['page' => 1]);
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals', null, ['page' => 1]);
+
+        $this->sdk->crmLeads()->getEntities();
+        $this->assertRequestSent('GET', '/crm/v1/entities/leads');
+
+        $this->sdk->crmContacts()->getEntities();
+        $this->assertRequestSent('GET', '/crm/v1/entities/contacts');
+
+        $this->sdk->crmCompanies()->getEntities();
+        $this->assertRequestSent('GET', '/crm/v1/entities/companies');
+    }
+
+    public function test_crud(): void
+    {
+        $this->sdk->crmDeals()->createEntity(['title' => 'D']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals', ['title' => 'D']);
+
+        $this->sdk->crmDeals()->updateEntity(7, ['title' => 'D2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/7', ['title' => 'D2']);
+
+        $this->sdk->crmDeals()->deleteEntity(7);
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/7');
+    }
+
+    public function test_mass_deletion_sends_wrapped_body_and_query(): void
+    {
+        $this->sdk->crmDeals()->massDeletion([1, 2], [3], false, ['q' => 'x']);
+
+        $this->assertRequestSent(
+            'DELETE',
+            '/crm/v1/entities/deals/mass_deletion',
+            ['all' => false, 'entity_ids' => [1, 2], 'except_ids' => [3]],
+            ['q' => 'x'],
+        );
+    }
+
+    public function test_mass_editing_sends_payload_and_settings(): void
+    {
+        $this->sdk->crmDeals()->massEditing(['stage' => 'won'], ['notify' => true], [1], [], true);
+
+        $this->assertRequestSent(
+            'PATCH',
+            '/crm/v1/entities/deals/mass_edit',
+            ['all' => true, 'entity_ids' => [1], 'except_ids' => [], 'payload' => ['stage' => 'won'], 'settings' => ['notify' => true]],
+        );
+    }
+
+    public function test_fields_and_lists(): void
+    {
+        $this->sdk->crmDeals()->getFields();
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/fields');
+
+        $this->sdk->crmDeals()->createField(['name' => 'X']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/fields', ['name' => 'X']);
+
+        $this->sdk->crmDeals()->updateField('code1', ['name' => 'Y']);
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/fields/code1', ['name' => 'Y']);
+
+        $this->sdk->crmDeals()->deleteField('code1');
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/fields/code1');
+
+        $this->sdk->crmDeals()->updateListValues('code1', [['value' => 'a']]);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/lists/code1', [['value' => 'a']]);
+
+        $this->sdk->crmDeals()->deleteListValue('code1', 'val1');
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/lists/code1/val1');
+    }
+
+    public function test_stage_helpers(): void
+    {
+        $this->sdk->crmLeads()->getByStage(5);
+        $this->assertRequestSent('GET', '/crm/v1/entities/leads/kanban/stage/5');
+
+        $this->sdk->crmDeals()->moveFromStageToStage(7, 9, 3);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/7/move/stage/9', ['reason_id' => 3]);
+    }
+}

--- a/tests/Services/CrmFunnelsAndStagesTest.php
+++ b/tests/Services/CrmFunnelsAndStagesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmFunnelsAndStagesTest extends TestCase
+{
+    public function test_funnels_service_deals(): void
+    {
+        $this->sdk->crmDealsFunnels()->getFunnels();
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/funnel');
+
+        $this->sdk->crmDealsFunnels()->createFunnel(['title' => 'Main']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/funnel', ['title' => 'Main']);
+
+        $this->sdk->crmDealsFunnels()->updateFunnel(2, ['title' => 'M2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/funnel/2', ['title' => 'M2']);
+
+        $this->sdk->crmDealsFunnels()->deleteFunnel(2);
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/funnel/2');
+
+        $this->sdk->crmDealsFunnels()->getStagesByFunnel(3);
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/kanban/stage', null, ['funnel_id' => 3]);
+    }
+
+    public function test_funnels_service_leads_namespace(): void
+    {
+        $this->sdk->crmLeadsFunnels()->getFunnels();
+        $this->assertRequestSent('GET', '/crm/v1/entities/leads/funnel');
+    }
+
+    public function test_funnel_reasons_use_shared_reasons_namespace(): void
+    {
+        $this->sdk->crmDealsFunnels()->createStageReason(4, ['name' => 'lost']);
+        $this->assertRequestSent('POST', '/crm/v1/reasons/4', ['name' => 'lost']);
+
+        $this->sdk->crmDealsFunnels()->updateStageReason(9, ['name' => 'x']);
+        $this->assertRequestSent('PATCH', '/crm/v1/reasons/9', ['name' => 'x']);
+
+        $this->sdk->crmDealsFunnels()->deleteStageReason(9);
+        $this->assertRequestSent('DELETE', '/crm/v1/reasons/9');
+    }
+
+    public function test_stages_service(): void
+    {
+        $this->sdk->crmDealsStages()->getStages();
+        $this->assertRequestSent('GET', '/crm/v1/entities/deals/kanban/stage');
+
+        $this->sdk->crmDealsStages()->createStage(['name' => 'New']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/deals/kanban/stage', ['name' => 'New']);
+
+        $this->sdk->crmDealsStages()->updateStage(6, ['name' => 'N2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/entities/deals/kanban/stage/6', ['name' => 'N2']);
+
+        $this->sdk->crmDealsStages()->deleteStage(6);
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/deals/kanban/stage/6');
+    }
+
+    public function test_stages_service_reasons(): void
+    {
+        $this->sdk->crmLeadsStages()->getReasons(11);
+        $this->assertRequestSent('GET', '/crm/v1/reasons/11');
+
+        $this->sdk->crmLeadsStages()->createReason(11, ['name' => 'r']);
+        $this->assertRequestSent('POST', '/crm/v1/reasons/11', ['name' => 'r']);
+    }
+}

--- a/tests/Services/CrmProductsTest.php
+++ b/tests/Services/CrmProductsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmProductsTest extends TestCase
+{
+    public function test_products_catalog_crud(): void
+    {
+        $this->sdk->crmProducts()->getProducts(['page' => 1]);
+        $this->assertRequestSent('GET', '/crm/v1/static/products', null, ['page' => 1]);
+
+        $this->sdk->crmProducts()->createProduct(['name' => 'Widget']);
+        $this->assertRequestSent('POST', '/crm/v1/static/products', ['name' => 'Widget']);
+
+        $this->sdk->crmProducts()->updateProduct(3, ['name' => 'W2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/static/products/3', ['name' => 'W2']);
+
+        $this->sdk->crmProducts()->deleteProduct(3);
+        $this->assertRequestSent('DELETE', '/crm/v1/static/products/3');
+    }
+
+    public function test_product_fields_use_dynamic_namespace(): void
+    {
+        $this->sdk->crmProducts()->getFields();
+        $this->assertRequestSent('GET', '/crm/v1/entities/products/fields');
+
+        $this->sdk->crmProducts()->createField(['name' => 'F']);
+        $this->assertRequestSent('POST', '/crm/v1/entities/products/fields', ['name' => 'F']);
+
+        $this->sdk->crmProducts()->deleteListValue('code1', 'val1');
+        $this->assertRequestSent('DELETE', '/crm/v1/entities/products/lists/code1/val1');
+    }
+
+    public function test_categories_units_taxes_price_types(): void
+    {
+        $this->sdk->crmProductsUnits()->getProductUnits();
+        $this->assertRequestSent('GET', '/crm/v1/static/measurement-units');
+
+        $this->sdk->crmProductsTaxes()->createProductTax(['name' => 'VAT']);
+        $this->assertRequestSent('POST', '/crm/v1/static/taxes', ['name' => 'VAT']);
+
+        $this->sdk->crmProductsPriceTypes()->getProductPriceTypes();
+        $this->assertRequestSent('GET', '/crm/v1/static/product-price-types');
+
+        $this->sdk->crmProductsCategories()->getProductCategories();
+        $this->assertRequestSent('GET', '/crm/v1/static/product-categories');
+    }
+
+    public function test_category_delete_builds_query(): void
+    {
+        $this->sdk->crmProductsCategories()->deleteProductCategory(5, 1, true);
+
+        $this->assertRequestSent(
+            'DELETE',
+            '/crm/v1/static/product-categories/5',
+            null,
+            ['category_for_products' => 1, 'child_categories' => 'delete'],
+        );
+    }
+
+    public function test_products_for_entity(): void
+    {
+        $this->sdk->crmProductsForEntity()->getInfoProductsForEntity('deals', 42);
+        $this->assertRequestSent('GET', '/crm/v1/static/entity-product-lists', null, ['entity_type' => 'deals', 'entity_id' => 42]);
+
+        $this->sdk->crmProductsForEntity()->createProductsForEntity([['id' => 1]]);
+        $this->assertRequestSent('POST', '/crm/v1/static/list-products/bulk', ['list_products' => [['id' => 1]]]);
+
+        $this->sdk->crmProductsForEntity()->deleteProductsForEntity([1, 2]);
+        $this->assertRequestSent('DELETE', '/crm/v1/static/list-products/bulk', null, ['list_products' => [1, 2]]);
+    }
+}

--- a/tests/Services/CrmRequisitesAndTemplatesTest.php
+++ b/tests/Services/CrmRequisitesAndTemplatesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmRequisitesAndTemplatesTest extends TestCase
+{
+    public function test_requisite_templates_and_cards(): void
+    {
+        $this->sdk->crmRequisites()->getTemplates(['page' => 1, 'list' => 20]);
+        $this->assertRequestSent('GET', '/crm/v1/requisites/templates', null, ['page' => 1, 'list' => 20]);
+
+        $this->sdk->crmRequisites()->getCardRequisites(['entity_id' => 5]);
+        $this->assertRequestSent('GET', '/crm/v1/requisites', null, ['entity_id' => 5]);
+
+        $this->sdk->crmRequisites()->createCardRequisites(['name' => 'R'], ['entity_id' => 5]);
+        $this->assertRequestSent('POST', '/crm/v1/requisites', ['name' => 'R'], ['entity_id' => 5]);
+
+        $this->sdk->crmRequisites()->updateCardRequisites(9, ['name' => 'R2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/requisites/9', ['name' => 'R2']);
+
+        $this->sdk->crmRequisites()->deleteCardRequisites(9);
+        $this->assertRequestSent('DELETE', '/crm/v1/requisites/9');
+    }
+
+    public function test_bank_requisites_nested_paths(): void
+    {
+        $this->sdk->crmRequisites()->createBankRequisites(9, ['iban' => 'UA...']);
+        $this->assertRequestSent('POST', '/crm/v1/requisites/9/bank_requisites', ['iban' => 'UA...']);
+
+        $this->sdk->crmRequisites()->updateBankRequisites(9, 3, ['iban' => 'UA2']);
+        $this->assertRequestSent('PATCH', '/crm/v1/requisites/9/bank_requisites/3', ['iban' => 'UA2']);
+
+        $this->sdk->crmRequisites()->deleteBankRequisites(9, 3);
+        $this->assertRequestSent('DELETE', '/crm/v1/requisites/9/bank_requisites/3');
+
+        $this->sdk->crmRequisites()->attachBankRequisites(9, ['ref' => 1]);
+        $this->assertRequestSent('POST', '/crm/v1/requisites/9/bank_requisites/references/attach-reference', null, ['ref' => 1]);
+    }
+
+    public function test_document_templates(): void
+    {
+        $this->sdk->crmDocumentTemplates()->getDocumentTemplates(['page' => 1]);
+        $this->assertRequestSent('GET', '/crm/v1/documents/templates', null, ['page' => 1]);
+
+        $this->sdk->crmDocumentTemplates()->getDocumentTemplatesFields();
+        $this->assertRequestSent('GET', '/crm/v1/documents/templates/fields');
+
+        $this->sdk->crmDocumentTemplates()->createTemplate(['name' => 'T']);
+        $this->assertRequestSent('POST', '/crm/v1/documents/templates', ['name' => 'T']);
+
+        $this->sdk->crmDocumentTemplates()->deleteTemplate(4);
+        $this->assertRequestSent('DELETE', '/crm/v1/documents/templates/4');
+
+        $this->sdk->crmDocumentTemplates()->deleteArrayTemplates([1, 2, 3]);
+        $this->assertRequestSent('DELETE', '/crm/v1/documents/templates', null, ['ids' => [1, 2, 3]]);
+    }
+}


### PR DESCRIPTION
## Summary

First batch of JS-SDK parity: **11 dedicated CRM-family services** (~80 methods), all under `/crm/v1`, mirroring the JS SDK's per-entity service design. Wired as new accessors on the connector.

This is **batch 1 of the JS-parity roadmap** — subsequent PRs will cover deepening the existing 14 services, platform services (Profile/Roles/Webhooks/…), and growth modules (Marketing/Analytics/…).

## New services

| Accessor(s) | Service | Notes |
| --- | --- | --- |
| `crmDeals()` / `crmLeads()` / `crmContacts()` / `crmCompanies()` | `CrmEntityService` | Parameterized by entity type. CRUD, mass deletion/editing, fields, list values, `moveFromStageToStage`, `getByStage`. |
| `crmDealsFunnels()` / `crmLeadsFunnels()` | `CrmFunnelsService` | Funnel + stage CRUD, fail reasons per funnel. |
| `crmDealsStages()` / `crmLeadsStages()` | `CrmStagesService` | Stage CRUD, fail reasons per record. |
| `crmProducts()` | `CrmProductsService` | Catalog CRUD + mass ops + dynamic product fields/lists. |
| `crmProductsCategories()` | `CrmProductsCategoryService` | Incl. delete-with-reassignment query. |
| `crmProductsUnits()` / `crmProductsTaxes()` / `crmProductsPriceTypes()` | catalog services | CRUD. |
| `crmProductsForEntity()` | `CrmProductsForEntityService` | Line products, incl. bulk create/update/delete + aggregated info. |
| `crmRequisites()` | `CrmRequisitesService` | Card requisites + nested bank requisites + attach references. |
| `crmDocumentTemplates()` | `CrmDocumentTemplatesService` | Templates + fields + batch delete. |

## Design notes

- Endpoints mirror the JS services **exactly**: no trailing slashes, wrapped bodies for mass/bulk ops (`{ all, entity_ids, except_ids }`, `{ list_products }`), and the shared `/crm/v1/reasons` namespace.
- Entity-scoped services are **parameterized** (`new CrmEntityService($http, 'deals')`) — the DRY, faithful mirror of JS's four near-identical per-entity services.
- The existing generic `CrmService` is untouched; these are additive.

## Tests

**+19 tests → 75 total, 125 assertions**, all offline via Saloon `MockClient`, asserting method + endpoint + body + query for each new service (incl. the parameterized deals-vs-leads namespaces, wrapped mass/bulk bodies, and the category-delete query).

## Verification

- ✅ `composer test` → OK (75 tests, 125 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)