### PR TITLE
Platform services: Profile, Roles, Webhooks, OAuth, Invites, Notifications, Timer, History (batch 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Every service is reachable through an accessor on the connector:
 | `$sdk->messenger()` | `MessengerService` | `messenger/v1` |
 | `$sdk->settings()` | `SettingsService` | `settings/v1` |
 | `$sdk->auth()` | `AuthService` | `auth/v1` |
+| `$sdk->profile()` | `ProfileService` | `company/v1/users/me` |
+| `$sdk->roles()` | `RolesService` | `company/v1` · `crm/v1` |
+| `$sdk->webhooks()` | `WebhooksService` | `company/v1/webhooks` |
+| `$sdk->oauthClients()` | `OAuthClientsService` | `company/v1/oauth_clients` |
+| `$sdk->invites()` | `InvatesService` | `company/v1` |
+| `$sdk->notifications()` | `NotificationsService` | `notifications/v1` |
+| `$sdk->tasksTimer()` | `TasksTimerService` | `tasks/v1/timer` |
+| `$sdk->history()` | `HistoryService` | `history/v1` |
 
 ### CRM-family services (JS-parity)
 
@@ -200,6 +208,32 @@ $sdk->messenger()->updateSettings(['sound' => false]);
 ```php
 $tokens = $sdk->auth()->applicationSignIn($clientId, $clientSecret); // Tokens DTO
 $sdk->auth()->refreshToken();
+```
+
+### Platform services
+
+```php
+// Profile (current user)
+$sdk->profile()->getProfile();
+$sdk->profile()->enable2Fa();
+$sdk->profile()->getRequisites();
+
+// Roles & permissions
+$sdk->roles()->getRoles();
+$sdk->roles()->getPermissionsFunnels('admin');
+
+// Webhooks (outgoing, or incoming via the $isIncoming flag)
+$sdk->webhooks()->getWebhooks(page: 1);
+$sdk->webhooks()->createWebhook(['url' => 'https://...'], isIncoming: true);
+
+// OAuth clients, invites, notifications
+$sdk->oauthClients()->getOAuthClients();
+$sdk->invites()->createInvatesBatch(['ada@example.com']);
+$sdk->notifications()->getNotifications();
+
+// Task timer + change history
+$sdk->tasksTimer()->startTimer($taskId);
+$sdk->history()->getChangesHistory('crm', 'deals', 42, ['page' => 1]);
 ```
 
 ## Error handling

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Every service is reachable through an accessor on the connector:
 | `$sdk->roles()` | `RolesService` | `company/v1` · `crm/v1` |
 | `$sdk->webhooks()` | `WebhooksService` | `company/v1/webhooks` |
 | `$sdk->oauthClients()` | `OAuthClientsService` | `company/v1/oauth_clients` |
-| `$sdk->invites()` | `InvatesService` | `company/v1` |
+| `$sdk->invites()` | `InvitesService` | `company/v1` |
 | `$sdk->notifications()` | `NotificationsService` | `notifications/v1` |
 | `$sdk->tasksTimer()` | `TasksTimerService` | `tasks/v1/timer` |
 | `$sdk->history()` | `HistoryService` | `history/v1` |
@@ -228,7 +228,7 @@ $sdk->webhooks()->createWebhook(['url' => 'https://...'], isIncoming: true);
 
 // OAuth clients, invites, notifications
 $sdk->oauthClients()->getOAuthClients();
-$sdk->invites()->createInvatesBatch(['ada@example.com']);
+$sdk->invites()->createInvitesBatch(['ada@example.com']);
 $sdk->notifications()->getNotifications();
 
 // Task timer + change history

--- a/src/Http/Client/UspacySDK.php
+++ b/src/Http/Client/UspacySDK.php
@@ -26,7 +26,7 @@ use Uspacy\SDK\Services\EmailsService;
 use Uspacy\SDK\Services\FilesService;
 use Uspacy\SDK\Services\GroupsService;
 use Uspacy\SDK\Services\HistoryService;
-use Uspacy\SDK\Services\InvatesService;
+use Uspacy\SDK\Services\InvitesService;
 use Uspacy\SDK\Services\MessengerService;
 use Uspacy\SDK\Services\NewsFeedService;
 use Uspacy\SDK\Services\NotificationsService;
@@ -238,9 +238,9 @@ class UspacySDK extends Connector
         return new OAuthClientsService($this->http());
     }
 
-    public function invites(): InvatesService
+    public function invites(): InvitesService
     {
-        return new InvatesService($this->http());
+        return new InvitesService($this->http());
     }
 
     public function notifications(): NotificationsService

--- a/src/Http/Client/UspacySDK.php
+++ b/src/Http/Client/UspacySDK.php
@@ -25,12 +25,20 @@ use Uspacy\SDK\Services\DepartmentsService;
 use Uspacy\SDK\Services\EmailsService;
 use Uspacy\SDK\Services\FilesService;
 use Uspacy\SDK\Services\GroupsService;
+use Uspacy\SDK\Services\HistoryService;
+use Uspacy\SDK\Services\InvatesService;
 use Uspacy\SDK\Services\MessengerService;
 use Uspacy\SDK\Services\NewsFeedService;
+use Uspacy\SDK\Services\NotificationsService;
+use Uspacy\SDK\Services\OAuthClientsService;
+use Uspacy\SDK\Services\ProfileService;
+use Uspacy\SDK\Services\RolesService;
 use Uspacy\SDK\Services\SettingsService;
 use Uspacy\SDK\Services\SmartObjectsService;
 use Uspacy\SDK\Services\TasksService;
+use Uspacy\SDK\Services\TasksTimerService;
 use Uspacy\SDK\Services\UsersService;
+use Uspacy\SDK\Services\WebhooksService;
 
 class UspacySDK extends Connector
 {
@@ -208,6 +216,46 @@ class UspacySDK extends Connector
     public function auth(): AuthService
     {
         return new AuthService($this->http());
+    }
+
+    public function profile(): ProfileService
+    {
+        return new ProfileService($this->http());
+    }
+
+    public function roles(): RolesService
+    {
+        return new RolesService($this->http());
+    }
+
+    public function webhooks(): WebhooksService
+    {
+        return new WebhooksService($this->http());
+    }
+
+    public function oauthClients(): OAuthClientsService
+    {
+        return new OAuthClientsService($this->http());
+    }
+
+    public function invites(): InvatesService
+    {
+        return new InvatesService($this->http());
+    }
+
+    public function notifications(): NotificationsService
+    {
+        return new NotificationsService($this->http());
+    }
+
+    public function tasksTimer(): TasksTimerService
+    {
+        return new TasksTimerService($this->http());
+    }
+
+    public function history(): HistoryService
+    {
+        return new HistoryService($this->http());
     }
 
     private function initRetryConfig(): void

--- a/src/Services/HistoryService.php
+++ b/src/Services/HistoryService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * History (change log) service.
+ *
+ * Mirrors the JS SDK's HistoryService (`/history/v1`).
+ */
+class HistoryService extends Service
+{
+    private const NAMESPACE = '/history/v1';
+
+    /**
+     * Get the change history for an entity record.
+     *
+     * @param  string  $service  originating service (e.g. crm, tasks)
+     * @param  string  $entityTableName  entity table name
+     * @param  int|string  $id  record id
+     * @param  array  $params  query params (page, list, action)
+     */
+    public function getChangesHistory(string $service, string $entityTableName, $id, array $params = []): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/{$service}/{$entityTableName}/{$id}", $params);
+    }
+}

--- a/src/Services/InvatesService.php
+++ b/src/Services/InvatesService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Invitations service.
+ *
+ * Mirrors the JS SDK's InvatesService under `/company/v1`.
+ */
+class InvatesService extends Service
+{
+    private const NAMESPACE = '/company/v1';
+
+    /**
+     * Check whether an email already has an invitation.
+     */
+    public function checkInvateByEmail(string $email): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/users/check_invite', ['email' => $email]);
+    }
+
+    /**
+     * Create invitations.
+     *
+     * @param  array  $body  list of invitation payloads
+     */
+    public function createInvates(array $body): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/invites/email', $body);
+    }
+
+    /**
+     * Create invitations in batch from a list of emails.
+     *
+     * @param  array  $emails  list of email addresses
+     */
+    public function createInvatesBatch(array $emails): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/invites/email/batch', $emails);
+    }
+
+    /**
+     * Resend an invitation to a user.
+     *
+     * @param  int|string  $userId
+     */
+    public function resendInvateByUserId($userId): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/invites/email/{$userId}/repeat_invitation");
+    }
+
+    /**
+     * Delete an invitation by user id.
+     *
+     * @param  int|string  $userId
+     */
+    public function deleteInvateByUserId($userId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/invites/email/{$userId}");
+    }
+}

--- a/src/Services/InvitesService.php
+++ b/src/Services/InvitesService.php
@@ -7,16 +7,17 @@ use Saloon\Http\Response;
 /**
  * Invitations service.
  *
- * Mirrors the JS SDK's InvatesService under `/company/v1`.
+ * Mirrors the JS SDK's invitations service (spelled "InvatesService" there;
+ * corrected to Invites here) under `/company/v1`.
  */
-class InvatesService extends Service
+class InvitesService extends Service
 {
     private const NAMESPACE = '/company/v1';
 
     /**
      * Check whether an email already has an invitation.
      */
-    public function checkInvateByEmail(string $email): Response
+    public function checkInviteByEmail(string $email): Response
     {
         return $this->http->get(self::NAMESPACE . '/users/check_invite', ['email' => $email]);
     }
@@ -26,7 +27,7 @@ class InvatesService extends Service
      *
      * @param  array  $body  list of invitation payloads
      */
-    public function createInvates(array $body): Response
+    public function createInvites(array $body): Response
     {
         return $this->http->post(self::NAMESPACE . '/invites/email', $body);
     }
@@ -36,7 +37,7 @@ class InvatesService extends Service
      *
      * @param  array  $emails  list of email addresses
      */
-    public function createInvatesBatch(array $emails): Response
+    public function createInvitesBatch(array $emails): Response
     {
         return $this->http->post(self::NAMESPACE . '/invites/email/batch', $emails);
     }
@@ -46,7 +47,7 @@ class InvatesService extends Service
      *
      * @param  int|string  $userId
      */
-    public function resendInvateByUserId($userId): Response
+    public function resendInviteByUserId($userId): Response
     {
         return $this->http->patch(self::NAMESPACE . "/invites/email/{$userId}/repeat_invitation");
     }
@@ -56,7 +57,7 @@ class InvatesService extends Service
      *
      * @param  int|string  $userId
      */
-    public function deleteInvateByUserId($userId): Response
+    public function deleteInviteByUserId($userId): Response
     {
         return $this->http->delete(self::NAMESPACE . "/invites/email/{$userId}");
     }

--- a/src/Services/NotificationsService.php
+++ b/src/Services/NotificationsService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Notifications service.
+ *
+ * Mirrors the JS SDK's NotificationsService (`/notifications/v1/notifications`).
+ */
+class NotificationsService extends Service
+{
+    private const NAMESPACE = '/notifications/v1/notifications';
+
+    /**
+     * Get the current user's notifications.
+     */
+    public function getNotifications(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+}

--- a/src/Services/OAuthClientsService.php
+++ b/src/Services/OAuthClientsService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * OAuth clients service.
+ *
+ * Mirrors the JS SDK's OAuthClientsService (`/company/v1/oauth_clients`).
+ */
+class OAuthClientsService extends Service
+{
+    private const NAMESPACE = '/company/v1/oauth_clients';
+
+    /**
+     * Get all OAuth clients.
+     */
+    public function getOAuthClients(): Response
+    {
+        return $this->http->get(self::NAMESPACE);
+    }
+
+    /**
+     * Create an OAuth client.
+     */
+    public function createOAuthClient(array $body): Response
+    {
+        return $this->http->post(self::NAMESPACE, $body);
+    }
+
+    /**
+     * Update an OAuth client.
+     *
+     * @param  int|string  $id
+     */
+    public function updateOAuthClient($id, array $body): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$id}", $body);
+    }
+
+    /**
+     * Delete an OAuth client.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteOAuthClient($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$id}");
+    }
+
+    /**
+     * Get the permissions available to OAuth clients.
+     */
+    public function getAvailablePermissions(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/available_permissions');
+    }
+}

--- a/src/Services/ProfileService.php
+++ b/src/Services/ProfileService.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Profile service (the current authenticated user).
+ *
+ * Mirrors the JS SDK's ProfileService: the "me" endpoints under
+ * `/company/v1/users/me`, profile custom fields under
+ * `/company/v1/custom_fields/users`, and the user's own requisites under
+ * `/crm/v1/requisites`.
+ */
+class ProfileService extends Service
+{
+    private const NAMESPACE = '/company/v1/users/me';
+
+    private const FIELDS = '/company/v1/custom_fields/users';
+
+    private const REQUISITES = '/crm/v1/requisites';
+
+    /**
+     * Get the current user's profile.
+     */
+    public function getProfile(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/');
+    }
+
+    /**
+     * Get the current user's online status.
+     */
+    public function getProfileOnlineStatus(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/online');
+    }
+
+    /**
+     * Get the current user's two-factor authentication status.
+     */
+    public function get2FaStatus(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/twofa_status/');
+    }
+
+    /**
+     * Enable two-factor authentication for the current user.
+     */
+    public function enable2Fa(): Response
+    {
+        return $this->http->patch(self::NAMESPACE . '/twofa_enable/');
+    }
+
+    /**
+     * Disable two-factor authentication for the current user.
+     */
+    public function disable2Fa(): Response
+    {
+        return $this->http->patch(self::NAMESPACE . '/twofa_disable/');
+    }
+
+    /**
+     * Get the current user's portal settings.
+     */
+    public function getPortalSettings(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/settings/');
+    }
+
+    /**
+     * Update the current user's portal settings.
+     */
+    public function updatePortalSettings(array $settings): Response
+    {
+        return $this->http->patch(self::NAMESPACE . '/settings/', $settings);
+    }
+
+    /**
+     * Get the current user's requisites.
+     */
+    public function getRequisites(): Response
+    {
+        return $this->http->get(self::REQUISITES . '/');
+    }
+
+    /**
+     * Update a requisite.
+     *
+     * @param  int|string  $id
+     */
+    public function updateRequisite($id, array $body): Response
+    {
+        return $this->http->patch(self::REQUISITES . "/{$id}", $body);
+    }
+
+    /**
+     * Remove a requisite.
+     *
+     * @param  int|string  $id
+     */
+    public function removeRequisite($id): Response
+    {
+        return $this->http->delete(self::REQUISITES . "/{$id}");
+    }
+
+    /**
+     * Get requisite templates.
+     */
+    public function getTemplates(?int $page = null, ?int $list = null): Response
+    {
+        return $this->http->get(self::REQUISITES . '/templates', ['page' => $page, 'list' => $list]);
+    }
+
+    /**
+     * Get the basic (built-in) requisite templates.
+     */
+    public function getBasicTemplates(): Response
+    {
+        return $this->http->get(self::REQUISITES . '/templates/basic-templates');
+    }
+
+    /**
+     * Create a requisite template.
+     */
+    public function createTemplate(array $body): Response
+    {
+        return $this->http->post(self::REQUISITES . '/templates', $body);
+    }
+
+    /**
+     * Update a requisite template.
+     *
+     * @param  int|string  $id
+     */
+    public function updateTemplate($id, array $body): Response
+    {
+        return $this->http->patch(self::REQUISITES . "/templates/{$id}", $body);
+    }
+
+    /**
+     * Remove a requisite template.
+     *
+     * @param  int|string  $id
+     */
+    public function removeTemplate($id): Response
+    {
+        return $this->http->delete(self::REQUISITES . "/templates/{$id}");
+    }
+
+    /**
+     * Get bank requisites for a requisite.
+     *
+     * @param  int|string  $id
+     */
+    public function getBankRequisitesById($id): Response
+    {
+        return $this->http->get(self::REQUISITES . "/{$id}/bank_requisites/");
+    }
+
+    /**
+     * Get the profile custom fields.
+     */
+    public function getProfileFields(): Response
+    {
+        return $this->http->get(self::FIELDS . '/fields');
+    }
+
+    /**
+     * Create a profile custom field.
+     */
+    public function createProfileField(array $data): Response
+    {
+        return $this->http->post(self::FIELDS . '/fields', $data);
+    }
+
+    /**
+     * Update a profile custom field.
+     */
+    public function updateProfileField(string $fieldCode, array $data): Response
+    {
+        return $this->http->patch(self::FIELDS . "/fields/{$fieldCode}", $data);
+    }
+
+    /**
+     * Delete a profile custom field.
+     */
+    public function deleteProfileField(string $fieldCode): Response
+    {
+        return $this->http->delete(self::FIELDS . "/fields/{$fieldCode}");
+    }
+
+    /**
+     * Add/replace list values for a profile custom field.
+     */
+    public function updateProfileListValues(string $fieldCode, array $values): Response
+    {
+        return $this->http->post(self::FIELDS . "/lists/{$fieldCode}", $values);
+    }
+
+    /**
+     * Delete a single list value from a profile custom field.
+     */
+    public function deleteProfileListValues(string $fieldCode, string $value): Response
+    {
+        return $this->http->delete(self::FIELDS . "/lists/{$fieldCode}/{$value}");
+    }
+}

--- a/src/Services/RolesService.php
+++ b/src/Services/RolesService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Roles & permissions service.
+ *
+ * Mirrors the JS SDK's RolesService: roles under `/company/v1` and CRM funnel
+ * permissions under `/crm/v1`.
+ */
+class RolesService extends Service
+{
+    private const NAMESPACE = '/company/v1';
+
+    private const CRM_NAMESPACE = '/crm/v1';
+
+    /**
+     * Get all roles.
+     */
+    public function getRoles(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/roles');
+    }
+
+    /**
+     * Get a role by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getRole($id): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/roles/{$id}");
+    }
+
+    /**
+     * Create a role.
+     */
+    public function createRole(array $body): Response
+    {
+        return $this->http->post(self::NAMESPACE . '/roles/', $body);
+    }
+
+    /**
+     * Update a role.
+     *
+     * @param  int|string  $id
+     */
+    public function updateRole($id, array $body): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/roles/{$id}", $body);
+    }
+
+    /**
+     * Delete a role.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteRole($id): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/roles/{$id}");
+    }
+
+    /**
+     * Get the full permissions catalog.
+     */
+    public function getPermissions(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/permissions');
+    }
+
+    /**
+     * Get CRM funnel permissions, optionally for a specific role.
+     */
+    public function getPermissionsFunnels(?string $role = null): Response
+    {
+        return $this->http->get(self::CRM_NAMESPACE . '/permissions/funnels', ['role' => $role]);
+    }
+
+    /**
+     * Update CRM funnel permissions for roles.
+     */
+    public function updateRolePermissionsFunnels(array $body): Response
+    {
+        return $this->http->post(self::CRM_NAMESPACE . '/permissions', $body);
+    }
+}

--- a/src/Services/TasksTimerService.php
+++ b/src/Services/TasksTimerService.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Tasks timer service.
+ *
+ * Mirrors the JS SDK's TasksTimerService (`/tasks/v1/timer`).
+ */
+class TasksTimerService extends Service
+{
+    private const NAMESPACE = '/tasks/v1/timer';
+
+    /**
+     * Get the realtime timer state.
+     */
+    public function getTimerRealtime(): Response
+    {
+        return $this->http->get(self::NAMESPACE . '/realtime');
+    }
+
+    /**
+     * Get the timer entries for a task.
+     *
+     * @param  int|string  $taskId
+     */
+    public function getTimerList($taskId): Response
+    {
+        return $this->http->get(self::NAMESPACE . "/{$taskId}/");
+    }
+
+    /**
+     * Start the timer for a task.
+     *
+     * @param  int|string  $taskId
+     */
+    public function startTimer($taskId): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/{$taskId}/start");
+    }
+
+    /**
+     * Stop the timer for a task.
+     *
+     * @param  int|string  $taskId
+     */
+    public function stopTimer($taskId): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/{$taskId}/stop");
+    }
+
+    /**
+     * Create a manual timer entry for a task.
+     *
+     * @param  int|string  $taskId
+     */
+    public function createTimer($taskId, array $body): Response
+    {
+        return $this->http->post(self::NAMESPACE . "/{$taskId}/", $body);
+    }
+
+    /**
+     * Update a timer entry.
+     *
+     * @param  int|string  $taskId
+     * @param  int|string  $timerId
+     */
+    public function updateTimer($taskId, $timerId, array $body): Response
+    {
+        return $this->http->patch(self::NAMESPACE . "/{$taskId}/{$timerId}", $body);
+    }
+
+    /**
+     * Delete a timer entry.
+     *
+     * @param  int|string  $taskId
+     * @param  int|string  $timerId
+     */
+    public function deleteTimer($taskId, $timerId): Response
+    {
+        return $this->http->delete(self::NAMESPACE . "/{$taskId}/{$timerId}");
+    }
+}

--- a/src/Services/WebhooksService.php
+++ b/src/Services/WebhooksService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Webhooks service.
+ *
+ * Mirrors the JS SDK's WebhooksService. Each method targets either the outgoing
+ * (`/company/v1/webhooks`) or incoming (`/company/v1/incoming_webhooks`)
+ * namespace, selected by the `$isIncoming` flag.
+ */
+class WebhooksService extends Service
+{
+    private const OUTGOING = '/company/v1/webhooks';
+
+    private const INCOMING = '/company/v1/incoming_webhooks';
+
+    /**
+     * Get a page of webhooks.
+     */
+    public function getWebhooks(int $page = 1, ?int $list = null, ?string $name = null, bool $isIncoming = false): Response
+    {
+        return $this->http->get($this->namespace($isIncoming), [
+            'page' => $page,
+            'list' => $list,
+            'name' => $name,
+        ]);
+    }
+
+    /**
+     * Get a webhook by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getWebhookById($id, bool $isIncoming = false): Response
+    {
+        return $this->http->get($this->namespace($isIncoming) . "/{$id}/");
+    }
+
+    /**
+     * Create a webhook.
+     */
+    public function createWebhook(array $body, bool $isIncoming = false): Response
+    {
+        return $this->http->post($this->namespace($isIncoming), $body);
+    }
+
+    /**
+     * Update a webhook.
+     *
+     * @param  int|string  $id
+     */
+    public function updateWebhook($id, array $body, bool $isIncoming = false): Response
+    {
+        return $this->http->patch($this->namespace($isIncoming) . "/{$id}", $body);
+    }
+
+    /**
+     * Delete a webhook.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteWebhook($id, bool $isIncoming = false): Response
+    {
+        return $this->http->delete($this->namespace($isIncoming) . "/{$id}/");
+    }
+
+    /**
+     * Delete several webhooks at once.
+     *
+     * @param  array  $ids  webhook ids
+     */
+    public function deleteSelectedWebhooks(array $ids, bool $isIncoming = false): Response
+    {
+        return $this->http->delete($this->namespace($isIncoming), ['ids' => $ids]);
+    }
+
+    /**
+     * Toggle a webhook active/inactive.
+     *
+     * @param  int|string  $id
+     */
+    public function toggleWebhook($id, bool $isIncoming = false): Response
+    {
+        return $this->http->patch($this->namespace($isIncoming) . "/{$id}/toggle");
+    }
+
+    /**
+     * Repeat (re-fire) a webhook.
+     *
+     * @param  int|string  $id
+     */
+    public function repeatWebhook($id, bool $isIncoming = false): Response
+    {
+        return $this->http->patch($this->namespace($isIncoming) . "/{$id}/repeat");
+    }
+
+    private function namespace(bool $isIncoming): string
+    {
+        return $isIncoming ? self::INCOMING : self::OUTGOING;
+    }
+}

--- a/tests/Services/PlatformServicesTest.php
+++ b/tests/Services/PlatformServicesTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class PlatformServicesTest extends TestCase
+{
+    public function test_roles(): void
+    {
+        $this->sdk->roles()->getRoles();
+        $this->assertRequestSent('GET', '/company/v1/roles');
+
+        $this->sdk->roles()->getRole('admin');
+        $this->assertRequestSent('GET', '/company/v1/roles/admin');
+
+        $this->sdk->roles()->createRole(['name' => 'Sales']);
+        $this->assertRequestSent('POST', '/company/v1/roles/', ['name' => 'Sales']);
+
+        $this->sdk->roles()->getPermissionsFunnels('admin');
+        $this->assertRequestSent('GET', '/crm/v1/permissions/funnels', null, ['role' => 'admin']);
+
+        $this->sdk->roles()->updateRolePermissionsFunnels(['x' => 1]);
+        $this->assertRequestSent('POST', '/crm/v1/permissions', ['x' => 1]);
+    }
+
+    public function test_webhooks_outgoing_and_incoming(): void
+    {
+        $this->sdk->webhooks()->getWebhooks(1, 20, 'hook');
+        $this->assertRequestSent('GET', '/company/v1/webhooks', null, ['page' => 1, 'list' => 20, 'name' => 'hook']);
+
+        $this->sdk->webhooks()->getWebhookById(5, true);
+        $this->assertRequestSent('GET', '/company/v1/incoming_webhooks/5/');
+
+        $this->sdk->webhooks()->toggleWebhook(5);
+        $this->assertRequestSent('PATCH', '/company/v1/webhooks/5/toggle');
+
+        $this->sdk->webhooks()->deleteSelectedWebhooks([1, 2]);
+        $this->assertRequestSent('DELETE', '/company/v1/webhooks', ['ids' => [1, 2]]);
+    }
+
+    public function test_oauth_clients(): void
+    {
+        $this->sdk->oauthClients()->getOAuthClients();
+        $this->assertRequestSent('GET', '/company/v1/oauth_clients');
+
+        $this->sdk->oauthClients()->getAvailablePermissions();
+        $this->assertRequestSent('GET', '/company/v1/oauth_clients/available_permissions');
+
+        $this->sdk->oauthClients()->updateOAuthClient('abc', ['name' => 'X']);
+        $this->assertRequestSent('PATCH', '/company/v1/oauth_clients/abc', ['name' => 'X']);
+    }
+
+    public function test_invites(): void
+    {
+        $this->sdk->invites()->checkInvateByEmail('ada@example.com');
+        $this->assertRequestSent('GET', '/company/v1/users/check_invite', null, ['email' => 'ada@example.com']);
+
+        $this->sdk->invites()->createInvatesBatch(['a@x.com', 'b@x.com']);
+        $this->assertRequestSent('POST', '/company/v1/invites/email/batch', ['a@x.com', 'b@x.com']);
+
+        $this->sdk->invites()->resendInvateByUserId(7);
+        $this->assertRequestSent('PATCH', '/company/v1/invites/email/7/repeat_invitation');
+
+        $this->sdk->invites()->deleteInvateByUserId(7);
+        $this->assertRequestSent('DELETE', '/company/v1/invites/email/7');
+    }
+
+    public function test_notifications(): void
+    {
+        $this->sdk->notifications()->getNotifications();
+        $this->assertRequestSent('GET', '/notifications/v1/notifications');
+    }
+
+    public function test_tasks_timer(): void
+    {
+        $this->sdk->tasksTimer()->getTimerRealtime();
+        $this->assertRequestSent('GET', '/tasks/v1/timer/realtime');
+
+        $this->sdk->tasksTimer()->startTimer('t1');
+        $this->assertRequestSent('POST', '/tasks/v1/timer/t1/start');
+
+        $this->sdk->tasksTimer()->createTimer('t1', ['seconds' => 60]);
+        $this->assertRequestSent('POST', '/tasks/v1/timer/t1/', ['seconds' => 60]);
+
+        $this->sdk->tasksTimer()->updateTimer('t1', 'e2', ['seconds' => 90]);
+        $this->assertRequestSent('PATCH', '/tasks/v1/timer/t1/e2', ['seconds' => 90]);
+
+        $this->sdk->tasksTimer()->deleteTimer('t1', 'e2');
+        $this->assertRequestSent('DELETE', '/tasks/v1/timer/t1/e2');
+    }
+
+    public function test_history(): void
+    {
+        $this->sdk->history()->getChangesHistory('crm', 'deals', 42, ['page' => 1, 'action' => 'update']);
+        $this->assertRequestSent('GET', '/history/v1/crm/deals/42', null, ['page' => 1, 'action' => 'update']);
+    }
+}

--- a/tests/Services/PlatformServicesTest.php
+++ b/tests/Services/PlatformServicesTest.php
@@ -53,16 +53,16 @@ class PlatformServicesTest extends TestCase
 
     public function test_invites(): void
     {
-        $this->sdk->invites()->checkInvateByEmail('ada@example.com');
+        $this->sdk->invites()->checkInviteByEmail('ada@example.com');
         $this->assertRequestSent('GET', '/company/v1/users/check_invite', null, ['email' => 'ada@example.com']);
 
-        $this->sdk->invites()->createInvatesBatch(['a@x.com', 'b@x.com']);
+        $this->sdk->invites()->createInvitesBatch(['a@x.com', 'b@x.com']);
         $this->assertRequestSent('POST', '/company/v1/invites/email/batch', ['a@x.com', 'b@x.com']);
 
-        $this->sdk->invites()->resendInvateByUserId(7);
+        $this->sdk->invites()->resendInviteByUserId(7);
         $this->assertRequestSent('PATCH', '/company/v1/invites/email/7/repeat_invitation');
 
-        $this->sdk->invites()->deleteInvateByUserId(7);
+        $this->sdk->invites()->deleteInviteByUserId(7);
         $this->assertRequestSent('DELETE', '/company/v1/invites/email/7');
     }
 

--- a/tests/Services/ProfileServiceTest.php
+++ b/tests/Services/ProfileServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class ProfileServiceTest extends TestCase
+{
+    public function test_me_endpoints(): void
+    {
+        $this->sdk->profile()->getProfile();
+        $this->assertRequestSent('GET', '/company/v1/users/me/');
+
+        $this->sdk->profile()->getProfileOnlineStatus();
+        $this->assertRequestSent('GET', '/company/v1/users/me/online');
+
+        $this->sdk->profile()->getPortalSettings();
+        $this->assertRequestSent('GET', '/company/v1/users/me/settings/');
+
+        $this->sdk->profile()->updatePortalSettings(['theme' => 'dark']);
+        $this->assertRequestSent('PATCH', '/company/v1/users/me/settings/', ['theme' => 'dark']);
+    }
+
+    public function test_two_factor(): void
+    {
+        $this->sdk->profile()->get2FaStatus();
+        $this->assertRequestSent('GET', '/company/v1/users/me/twofa_status/');
+
+        $this->sdk->profile()->enable2Fa();
+        $this->assertRequestSent('PATCH', '/company/v1/users/me/twofa_enable/');
+
+        $this->sdk->profile()->disable2Fa();
+        $this->assertRequestSent('PATCH', '/company/v1/users/me/twofa_disable/');
+    }
+
+    public function test_requisites_and_templates(): void
+    {
+        $this->sdk->profile()->getRequisites();
+        $this->assertRequestSent('GET', '/crm/v1/requisites/');
+
+        $this->sdk->profile()->updateRequisite(9, ['name' => 'R']);
+        $this->assertRequestSent('PATCH', '/crm/v1/requisites/9', ['name' => 'R']);
+
+        $this->sdk->profile()->getTemplates(1, 20);
+        $this->assertRequestSent('GET', '/crm/v1/requisites/templates', null, ['page' => 1, 'list' => 20]);
+
+        $this->sdk->profile()->getBasicTemplates();
+        $this->assertRequestSent('GET', '/crm/v1/requisites/templates/basic-templates');
+
+        $this->sdk->profile()->getBankRequisitesById(9);
+        $this->assertRequestSent('GET', '/crm/v1/requisites/9/bank_requisites/');
+    }
+
+    public function test_profile_fields(): void
+    {
+        $this->sdk->profile()->getProfileFields();
+        $this->assertRequestSent('GET', '/company/v1/custom_fields/users/fields');
+
+        $this->sdk->profile()->createProfileField(['name' => 'F']);
+        $this->assertRequestSent('POST', '/company/v1/custom_fields/users/fields', ['name' => 'F']);
+
+        $this->sdk->profile()->deleteProfileListValues('code1', 'v1');
+        $this->assertRequestSent('DELETE', '/company/v1/custom_fields/users/lists/code1/v1');
+    }
+}


### PR DESCRIPTION
## Summary

Batch 3 of the JS-parity roadmap: **8 net-new platform services** (~57 methods), all additive, wired as connector accessors.

| Accessor | Service | Scope |
| --- | --- | --- |
| `$sdk->profile()` | `ProfileService` | `company/v1/users/me`, `custom_fields/users`, `crm/v1/requisites` |
| `$sdk->roles()` | `RolesService` | roles CRUD, permissions, CRM funnel permissions |
| `$sdk->webhooks()` | `WebhooksService` | outgoing + incoming (`$isIncoming` flag) |
| `$sdk->oauthClients()` | `OAuthClientsService` | clients CRUD + available permissions |
| `$sdk->invites()` | `InvatesService` | check/create/batch/resend/delete |
| `$sdk->notifications()` | `NotificationsService` | getNotifications |
| `$sdk->tasksTimer()` | `TasksTimerService` | realtime, start/stop, entries CRUD |
| `$sdk->history()` | `HistoryService` | entity change history |

## Highlights

- **Profile** covers the "me" surface: 2FA enable/disable/status, portal settings, the user's own requisites + templates + bank requisites, and profile custom fields/list values.
- **Webhooks** handles both outgoing and incoming namespaces through a single `$isIncoming` flag, mirroring the JS `getNamespace(isIncoming)` helper.

## Intentionally excluded: ResourcesService

The JS `ResourcesService` routes each resource type to a **different absolute host** via `getResourcesDomain()` (`window.location.origin` → `https://forms.uspa.cy`, etc.). That's browser-coupled and incompatible with a single-base-URL server SDK, so it's excluded (same rationale as Couchdb/Pouchdb). Can revisit if a server-side host mapping is provided.

## Tests

**+11 tests → 104 total, 221 assertions**, all offline via Saloon `MockClient`, asserting method + endpoint + body + query for each new service (incl. incoming-vs-outgoing webhooks and the requisites/templates paths).

## Verification

- ✅ `composer test` → OK (104 tests, 221 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

## Roadmap remaining

4. Growth/back-office (~50): Marketing, Analytics, Automations, Migrations
5. Collaboration deepening: Emails 5→26, Comments 1→9, Departments/Groups/Files gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)