### PR TITLE
Growth / back-office services: Marketing, Analytics, Automations, Migrations (batch 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Every service is reachable through an accessor on the connector:
 | `$sdk->notifications()` | `NotificationsService` | `notifications/v1` |
 | `$sdk->tasksTimer()` | `TasksTimerService` | `tasks/v1/timer` |
 | `$sdk->history()` | `HistoryService` | `history/v1` |
+| `$sdk->marketing()` | `MarketingService` | `marketing/v1` |
+| `$sdk->analytics()` | `AnalyticsService` | `analytics-backend/v1` |
+| `$sdk->automations()` | `AutomationsService` | `automations-backend/v1` |
+| `$sdk->migrations()` | `MigrationsService` | import status/control |
 
 ### CRM-family services (JS-parity)
 
@@ -234,6 +238,28 @@ $sdk->notifications()->getNotifications();
 // Task timer + change history
 $sdk->tasksTimer()->startTimer($taskId);
 $sdk->history()->getChangesHistory('crm', 'deals', 42, ['page' => 1]);
+```
+
+### Growth / back-office
+
+```php
+// Marketing: email templates, newsletters, domains, senders
+$sdk->marketing()->getEmailTemplates(['page' => 1]);
+$sdk->marketing()->createEmailNewsletter(['subject' => 'Launch']);
+$sdk->marketing()->sendEmailNewsletter(5);
+$sdk->marketing()->getSenders();
+
+// Analytics: reports, dashboards, funnel conversion
+$sdk->analytics()->getAnalyticsReportList();
+$sdk->analytics()->getFunnelConversion(['funnel_id' => 3]);
+
+// Automations: workers + workflows (processes)
+$sdk->automations()->getWorkflows();
+$sdk->automations()->createWorkflow(['name' => 'Onboarding']);
+
+// Migrations: import status & control
+$sdk->migrations()->getAllSystemsStatus();
+$sdk->migrations()->stopImport('trello');
 ```
 
 ## Error handling

--- a/src/Http/Client/UspacySDK.php
+++ b/src/Http/Client/UspacySDK.php
@@ -7,7 +7,9 @@ use Saloon\Http\Connector;
 use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 use Uspacy\SDK\Services\ActivitiesService;
+use Uspacy\SDK\Services\AnalyticsService;
 use Uspacy\SDK\Services\AuthService;
+use Uspacy\SDK\Services\AutomationsService;
 use Uspacy\SDK\Services\CommentsService;
 use Uspacy\SDK\Services\CrmDocumentTemplatesService;
 use Uspacy\SDK\Services\CrmEntityService;
@@ -27,7 +29,9 @@ use Uspacy\SDK\Services\FilesService;
 use Uspacy\SDK\Services\GroupsService;
 use Uspacy\SDK\Services\HistoryService;
 use Uspacy\SDK\Services\InvitesService;
+use Uspacy\SDK\Services\MarketingService;
 use Uspacy\SDK\Services\MessengerService;
+use Uspacy\SDK\Services\MigrationsService;
 use Uspacy\SDK\Services\NewsFeedService;
 use Uspacy\SDK\Services\NotificationsService;
 use Uspacy\SDK\Services\OAuthClientsService;
@@ -256,6 +260,26 @@ class UspacySDK extends Connector
     public function history(): HistoryService
     {
         return new HistoryService($this->http());
+    }
+
+    public function marketing(): MarketingService
+    {
+        return new MarketingService($this->http());
+    }
+
+    public function analytics(): AnalyticsService
+    {
+        return new AnalyticsService($this->http());
+    }
+
+    public function automations(): AutomationsService
+    {
+        return new AutomationsService($this->http());
+    }
+
+    public function migrations(): MigrationsService
+    {
+        return new MigrationsService($this->http());
     }
 
     private function initRetryConfig(): void

--- a/src/Services/AnalyticsService.php
+++ b/src/Services/AnalyticsService.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Analytics service.
+ *
+ * Mirrors the JS SDK's AnalyticsService: reports and dashboards under the
+ * `analytics-backend/v1` module, plus CRM funnel conversion under `/crm/v1`.
+ */
+class AnalyticsService extends Service
+{
+    private const REPORTS = '/analytics-backend/v1/reports';
+
+    private const DASHBOARDS = '/analytics-backend/v1/dashboards';
+
+    /**
+     * Get the analytics reports list.
+     *
+     * @param  array  $params  filter params
+     */
+    public function getAnalyticsReportList(array $params = []): Response
+    {
+        return $this->http->get(self::REPORTS . '/', $params);
+    }
+
+    /**
+     * Get an analytics report by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getAnalyticReport($id): Response
+    {
+        return $this->http->get(self::REPORTS . "/{$id}");
+    }
+
+    /**
+     * Create an analytics report.
+     */
+    public function createReport(array $data): Response
+    {
+        return $this->http->post(self::REPORTS . '/', $data);
+    }
+
+    /**
+     * Update an analytics report.
+     *
+     * @param  int|string  $id
+     */
+    public function updateReport($id, array $data): Response
+    {
+        return $this->http->patch(self::REPORTS . "/{$id}", $data);
+    }
+
+    /**
+     * Delete an analytics report.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteReport($id): Response
+    {
+        return $this->http->delete(self::REPORTS . "/{$id}");
+    }
+
+    /**
+     * Get the dashboards list.
+     */
+    public function getDashboardsLists(): Response
+    {
+        return $this->http->get(self::DASHBOARDS . '/');
+    }
+
+    /**
+     * Get a dashboard by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getDashboard($id): Response
+    {
+        return $this->http->get(self::DASHBOARDS . "/{$id}");
+    }
+
+    /**
+     * Create a dashboard.
+     */
+    public function createDashboard(array $data): Response
+    {
+        return $this->http->post(self::DASHBOARDS . '/', $data);
+    }
+
+    /**
+     * Update a dashboard.
+     *
+     * @param  int|string  $id
+     */
+    public function updateDashboard($id, array $data): Response
+    {
+        return $this->http->patch(self::DASHBOARDS . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a dashboard.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteDashboard($id): Response
+    {
+        return $this->http->delete(self::DASHBOARDS . "/{$id}");
+    }
+
+    /**
+     * Get CRM funnel conversion analytics.
+     *
+     * @param  array  $params  funnel conversion params
+     */
+    public function getFunnelConversion(array $params = []): Response
+    {
+        return $this->http->get('/crm/v1/analytics/funnels', $params);
+    }
+}

--- a/src/Services/AutomationsService.php
+++ b/src/Services/AutomationsService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Automations service.
+ *
+ * Mirrors the JS SDK's AutomationsService: automations ("workers") and workflows
+ * ("processes") under the `/automations-backend/v1` module.
+ */
+class AutomationsService extends Service
+{
+    private const WORKERS = '/automations-backend/v1/workers';
+
+    private const PROCESSES = '/automations-backend/v1/processes';
+
+    /**
+     * Get automations (workers).
+     *
+     * @param  array  $params  query params (page, list, search, sortBy, sortOrder)
+     */
+    public function getAutomations(array $params = []): Response
+    {
+        return $this->http->get(self::WORKERS, $params);
+    }
+
+    /**
+     * Delete an automation.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteAutomation($id): Response
+    {
+        return $this->http->delete(self::WORKERS . "/{$id}");
+    }
+
+    /**
+     * Toggle an automation active/inactive.
+     *
+     * @param  int|string  $id
+     */
+    public function toggleAutomation($id, array $body): Response
+    {
+        return $this->http->patch(self::WORKERS . "/{$id}", $body);
+    }
+
+    /**
+     * Get workflows (processes).
+     *
+     * @param  array  $params  query params (page, list, search, sortBy, sortOrder)
+     */
+    public function getWorkflows(array $params = []): Response
+    {
+        return $this->http->get(self::PROCESSES, $params);
+    }
+
+    /**
+     * Create a workflow.
+     */
+    public function createWorkflow(array $data): Response
+    {
+        return $this->http->post(self::PROCESSES, $data);
+    }
+
+    /**
+     * Update a workflow.
+     *
+     * @param  int|string  $id
+     */
+    public function updateWorkflow($id, array $data): Response
+    {
+        return $this->http->patch(self::PROCESSES . "/{$id}", $data);
+    }
+
+    /**
+     * Delete a workflow.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteWorkflow($id): Response
+    {
+        return $this->http->delete(self::PROCESSES . "/{$id}");
+    }
+
+    /**
+     * Toggle a workflow active/inactive.
+     *
+     * @param  int|string  $id
+     */
+    public function toggleWorkflow($id, array $body): Response
+    {
+        return $this->http->patch(self::PROCESSES . "/{$id}", $body);
+    }
+}

--- a/src/Services/MarketingService.php
+++ b/src/Services/MarketingService.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Marketing service.
+ *
+ * Mirrors the JS SDK's MarketingService: email templates (letters), email
+ * newsletters (mailings), sending domains and senders under the `/marketing/v1`
+ * module.
+ */
+class MarketingService extends Service
+{
+    private const TEMPLATES = '/marketing/v1/templates';
+
+    private const NEWSLETTERS = '/marketing/v1/newsletters';
+
+    /**
+     * Get email templates.
+     *
+     * @param  array  $params  filter params
+     */
+    public function getEmailTemplates(array $params = []): Response
+    {
+        return $this->http->get(self::TEMPLATES . '/letters', $params);
+    }
+
+    /**
+     * Get an email template by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getEmailTemplate($id): Response
+    {
+        return $this->http->get(self::TEMPLATES . "/letters/{$id}");
+    }
+
+    /**
+     * Create an email template.
+     */
+    public function createEmailTemplate(array $data): Response
+    {
+        return $this->http->post(self::TEMPLATES . '/letters', $data);
+    }
+
+    /**
+     * Update an email template.
+     *
+     * @param  int|string  $id
+     */
+    public function updateEmailTemplate($id, array $data): Response
+    {
+        return $this->http->patch(self::TEMPLATES . "/letters/{$id}", $data);
+    }
+
+    /**
+     * Delete an email template.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteEmailTemplate($id): Response
+    {
+        return $this->http->delete(self::TEMPLATES . "/letters/{$id}");
+    }
+
+    /**
+     * Mass edit email templates. The filter params are merged into the body.
+     *
+     * @param  array  $ids  template ids
+     * @param  array  $payload  fields to apply
+     * @param  bool  $all  edit every template matching $params
+     * @param  array  $params  list filter params (merged into the body)
+     */
+    public function massEditingEmailTemplates(array $ids, array $payload, bool $all = false, array $params = []): Response
+    {
+        return $this->http->post(self::TEMPLATES . '/letters/mass_edit', array_merge([
+            'all' => $all,
+            'payload' => $payload,
+            'id' => $ids,
+        ], $params));
+    }
+
+    /**
+     * Mass delete email templates. The filter params are merged into the body.
+     *
+     * @param  array  $ids  template ids
+     * @param  bool  $all  delete every template matching $params
+     * @param  array  $params  list filter params (merged into the body)
+     */
+    public function massDeletionEmailTemplates(array $ids, bool $all = false, array $params = []): Response
+    {
+        return $this->http->delete(self::TEMPLATES . '/letters/mass_deletion', array_merge([
+            'all' => $all,
+            'id' => $ids,
+        ], $params));
+    }
+
+    /**
+     * Get email newsletters.
+     *
+     * @param  array  $params  filter params
+     */
+    public function getEmailNewsletters(array $params = []): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . '/mailings', $params);
+    }
+
+    /**
+     * Get an email newsletter by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getEmailNewsletter($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/mailings/{$id}");
+    }
+
+    /**
+     * Get the statistics of an email newsletter.
+     *
+     * @param  int|string  $id
+     */
+    public function getEmailNewsletterStatistics($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/mailings/{$id}/statistics");
+    }
+
+    /**
+     * Get the recipients of an email newsletter.
+     *
+     * @param  int|string  $id
+     * @param  array  $params  recipients filter params
+     */
+    public function getEmailNewsletterRecipients($id, array $params = []): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/mailings/{$id}/recipients", $params);
+    }
+
+    /**
+     * Create an email newsletter.
+     */
+    public function createEmailNewsletter(array $data): Response
+    {
+        return $this->http->post(self::NEWSLETTERS . '/mailings', $data);
+    }
+
+    /**
+     * Update an email newsletter.
+     *
+     * @param  int|string  $id
+     */
+    public function updateEmailNewsletter($id, array $data): Response
+    {
+        return $this->http->patch(self::NEWSLETTERS . "/mailings/{$id}", $data);
+    }
+
+    /**
+     * Delete an email newsletter.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteEmailNewsletter($id): Response
+    {
+        return $this->http->delete(self::NEWSLETTERS . "/mailings/{$id}");
+    }
+
+    /**
+     * Send an email newsletter now.
+     *
+     * @param  int|string  $id
+     */
+    public function sendEmailNewsletter($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/mailings/send/{$id}");
+    }
+
+    /**
+     * Start the scheduled newsletter mailings.
+     */
+    public function startEmailNewsletterMailings(): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . '/mailings/start');
+    }
+
+    /**
+     * Get recipient counts by segments for a newsletter preset.
+     *
+     * @param  array  $presets  newsletter preset
+     */
+    public function getRecipientsCountsBySegments(array $presets): Response
+    {
+        return $this->http->post(self::NEWSLETTERS . '/mailings/recipients', ['presets' => $presets]);
+    }
+
+    /**
+     * Get the remaining newsletter credits.
+     */
+    public function getEmailNewslettersCredits(): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . '/mailings/credits');
+    }
+
+    /**
+     * Mass send email newsletters. The filter params are merged into the body.
+     *
+     * @param  array  $ids  newsletter ids
+     * @param  bool  $all  send every newsletter matching $params
+     * @param  array  $params  list filter params (merged into the body)
+     */
+    public function massSendingEmailNewsletters(array $ids, bool $all = false, array $params = []): Response
+    {
+        return $this->http->post(self::NEWSLETTERS . '/mailings/mass_send', array_merge([
+            'all' => $all,
+            'ids' => $ids,
+        ], $params));
+    }
+
+    /**
+     * Mass delete email newsletters. The filter params are merged into the body.
+     *
+     * @param  array  $ids  newsletter ids
+     * @param  bool  $all  delete every newsletter matching $params
+     * @param  array  $params  list filter params (merged into the body)
+     */
+    public function massDeletionEmailNewsletters(array $ids, bool $all = false, array $params = []): Response
+    {
+        return $this->http->delete(self::NEWSLETTERS . '/mailings/mass_deletion', array_merge([
+            'all' => $all,
+            'id' => $ids,
+        ], $params));
+    }
+
+    /**
+     * Get sending domains.
+     */
+    public function getDomains(): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . '/domains');
+    }
+
+    /**
+     * Get a sending domain by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getDomain($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/domains/{$id}");
+    }
+
+    /**
+     * Get the verification status of a sending domain.
+     *
+     * @param  int|string  $id
+     */
+    public function getDomainStatus($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/domains/status/{$id}");
+    }
+
+    /**
+     * Create a sending domain.
+     */
+    public function createDomain(array $data): Response
+    {
+        return $this->http->post(self::NEWSLETTERS . '/domains', $data);
+    }
+
+    /**
+     * Delete a sending domain.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteDomain($id): Response
+    {
+        return $this->http->delete(self::NEWSLETTERS . "/domains/{$id}");
+    }
+
+    /**
+     * Get senders.
+     */
+    public function getSenders(): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . '/senders');
+    }
+
+    /**
+     * Get a sender by id.
+     *
+     * @param  int|string  $id
+     */
+    public function getSender($id): Response
+    {
+        return $this->http->get(self::NEWSLETTERS . "/senders/{$id}");
+    }
+
+    /**
+     * Create a sender.
+     */
+    public function createSender(array $data): Response
+    {
+        return $this->http->post(self::NEWSLETTERS . '/senders', $data);
+    }
+
+    /**
+     * Update a sender.
+     *
+     * @param  int|string  $id
+     */
+    public function updateSender($id, array $data): Response
+    {
+        return $this->http->patch(self::NEWSLETTERS . "/senders/{$id}", $data);
+    }
+
+    /**
+     * Delete a sender.
+     *
+     * @param  int|string  $id
+     */
+    public function deleteSender($id): Response
+    {
+        return $this->http->delete(self::NEWSLETTERS . "/senders/{$id}");
+    }
+}

--- a/src/Services/MigrationsService.php
+++ b/src/Services/MigrationsService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Uspacy\SDK\Services;
+
+use Saloon\Http\Response;
+
+/**
+ * Migrations service (import status & control).
+ *
+ * Mirrors the status/control surface of the JS SDK's MigrationsService — import
+ * progress, data presence and stopping imports. The per-system entity
+ * calculate/import methods (bitrix24, amo, etc.) are intentionally omitted: in
+ * the JS SDK they branch across several ad-hoc gateway paths per system, which
+ * does not port cleanly to a single-base-URL server SDK.
+ */
+class MigrationsService extends Service
+{
+    private const IMPORT = '/import';
+
+    /**
+     * Get import status for all systems.
+     */
+    public function getAllSystemsStatus(): Response
+    {
+        return $this->http->get(self::IMPORT . '/progress');
+    }
+
+    /**
+     * Get import progress for a system.
+     */
+    public function getSystemProgress(string $system): Response
+    {
+        return $this->http->get(self::IMPORT . '/progress', ['system' => $system]);
+    }
+
+    /**
+     * Get Monday.com import progress for a system.
+     */
+    public function getMondayProgress(string $system): Response
+    {
+        return $this->http->get("/progress/{$system}");
+    }
+
+    /**
+     * Get data presence (Zoho).
+     */
+    public function getDataPresence(): Response
+    {
+        return $this->http->post('/dataPresence/zoho');
+    }
+
+    /**
+     * Stop a running import for a system.
+     */
+    public function stopImport(string $system): Response
+    {
+        if ($system === 'trello') {
+            return $this->http->post(self::IMPORT . '/v1/trello/stop');
+        }
+
+        return $this->http->get(self::IMPORT . '/stop', ['system' => $system]);
+    }
+}

--- a/tests/Services/GrowthServicesTest.php
+++ b/tests/Services/GrowthServicesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class GrowthServicesTest extends TestCase
+{
+    public function test_analytics_reports_and_dashboards(): void
+    {
+        $this->sdk->analytics()->getAnalyticsReportList(['page' => 1]);
+        $this->assertRequestSent('GET', '/analytics-backend/v1/reports/', null, ['page' => 1]);
+
+        $this->sdk->analytics()->getAnalyticReport('r1');
+        $this->assertRequestSent('GET', '/analytics-backend/v1/reports/r1');
+
+        $this->sdk->analytics()->createReport(['name' => 'R']);
+        $this->assertRequestSent('POST', '/analytics-backend/v1/reports/', ['name' => 'R']);
+
+        $this->sdk->analytics()->getDashboardsLists();
+        $this->assertRequestSent('GET', '/analytics-backend/v1/dashboards/');
+
+        $this->sdk->analytics()->updateDashboard('d1', ['title' => 'D']);
+        $this->assertRequestSent('PATCH', '/analytics-backend/v1/dashboards/d1', ['title' => 'D']);
+    }
+
+    public function test_analytics_funnel_conversion_uses_crm_namespace(): void
+    {
+        $this->sdk->analytics()->getFunnelConversion(['funnel_id' => 3]);
+        $this->assertRequestSent('GET', '/crm/v1/analytics/funnels', null, ['funnel_id' => 3]);
+    }
+
+    public function test_automations_workers_and_processes(): void
+    {
+        $this->sdk->automations()->getAutomations(['page' => 1]);
+        $this->assertRequestSent('GET', '/automations-backend/v1/workers', null, ['page' => 1]);
+
+        $this->sdk->automations()->toggleAutomation(5, ['active' => true]);
+        $this->assertRequestSent('PATCH', '/automations-backend/v1/workers/5', ['active' => true]);
+
+        $this->sdk->automations()->getWorkflows();
+        $this->assertRequestSent('GET', '/automations-backend/v1/processes');
+
+        $this->sdk->automations()->createWorkflow(['name' => 'W']);
+        $this->assertRequestSent('POST', '/automations-backend/v1/processes', ['name' => 'W']);
+
+        $this->sdk->automations()->updateWorkflow(9, ['name' => 'W2']);
+        $this->assertRequestSent('PATCH', '/automations-backend/v1/processes/9', ['name' => 'W2']);
+    }
+
+    public function test_migrations_status_and_control(): void
+    {
+        $this->sdk->migrations()->getAllSystemsStatus();
+        $this->assertRequestSent('GET', '/import/progress');
+
+        $this->sdk->migrations()->getSystemProgress('bitrix24');
+        $this->assertRequestSent('GET', '/import/progress', null, ['system' => 'bitrix24']);
+
+        $this->sdk->migrations()->getMondayProgress('monday');
+        $this->assertRequestSent('GET', '/progress/monday');
+
+        $this->sdk->migrations()->getDataPresence();
+        $this->assertRequestSent('POST', '/dataPresence/zoho');
+
+        $this->sdk->migrations()->stopImport('trello');
+        $this->assertRequestSent('POST', '/import/v1/trello/stop');
+
+        $this->sdk->migrations()->stopImport('amo');
+        $this->assertRequestSent('GET', '/import/stop', null, ['system' => 'amo']);
+    }
+}

--- a/tests/Services/MarketingServiceTest.php
+++ b/tests/Services/MarketingServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Uspacy\SDK\Tests\TestCase;
+
+class MarketingServiceTest extends TestCase
+{
+    public function test_email_templates(): void
+    {
+        $this->sdk->marketing()->getEmailTemplates(['page' => 1]);
+        $this->assertRequestSent('GET', '/marketing/v1/templates/letters', null, ['page' => 1]);
+
+        $this->sdk->marketing()->getEmailTemplate(5);
+        $this->assertRequestSent('GET', '/marketing/v1/templates/letters/5');
+
+        $this->sdk->marketing()->createEmailTemplate(['name' => 'T']);
+        $this->assertRequestSent('POST', '/marketing/v1/templates/letters', ['name' => 'T']);
+
+        $this->sdk->marketing()->updateEmailTemplate(5, ['name' => 'T2']);
+        $this->assertRequestSent('PATCH', '/marketing/v1/templates/letters/5', ['name' => 'T2']);
+
+        $this->sdk->marketing()->deleteEmailTemplate(5);
+        $this->assertRequestSent('DELETE', '/marketing/v1/templates/letters/5');
+    }
+
+    public function test_template_mass_ops_merge_params_into_body(): void
+    {
+        $this->sdk->marketing()->massEditingEmailTemplates([1, 2], ['active' => true], false, ['q' => 'x']);
+        $this->assertRequestSent('POST', '/marketing/v1/templates/letters/mass_edit', [
+            'all' => false,
+            'payload' => ['active' => true],
+            'id' => [1, 2],
+            'q' => 'x',
+        ]);
+
+        $this->sdk->marketing()->massDeletionEmailTemplates([1], true, ['q' => 'y']);
+        $this->assertRequestSent('DELETE', '/marketing/v1/templates/letters/mass_deletion', [
+            'all' => true,
+            'id' => [1],
+            'q' => 'y',
+        ]);
+    }
+
+    public function test_newsletters(): void
+    {
+        $this->sdk->marketing()->getEmailNewsletters(['page' => 1]);
+        $this->assertRequestSent('GET', '/marketing/v1/newsletters/mailings', null, ['page' => 1]);
+
+        $this->sdk->marketing()->getEmailNewsletterStatistics(5);
+        $this->assertRequestSent('GET', '/marketing/v1/newsletters/mailings/5/statistics');
+
+        $this->sdk->marketing()->sendEmailNewsletter(5);
+        $this->assertRequestSent('GET', '/marketing/v1/newsletters/mailings/send/5');
+
+        $this->sdk->marketing()->getRecipientsCountsBySegments(['segment' => 1]);
+        $this->assertRequestSent('POST', '/marketing/v1/newsletters/mailings/recipients', ['presets' => ['segment' => 1]]);
+
+        $this->sdk->marketing()->massSendingEmailNewsletters([1, 2], false, ['q' => 'z']);
+        $this->assertRequestSent('POST', '/marketing/v1/newsletters/mailings/mass_send', ['all' => false, 'ids' => [1, 2], 'q' => 'z']);
+    }
+
+    public function test_domains_and_senders(): void
+    {
+        $this->sdk->marketing()->getDomainStatus(3);
+        $this->assertRequestSent('GET', '/marketing/v1/newsletters/domains/status/3');
+
+        $this->sdk->marketing()->createDomain(['domain' => 'x.com']);
+        $this->assertRequestSent('POST', '/marketing/v1/newsletters/domains', ['domain' => 'x.com']);
+
+        $this->sdk->marketing()->getSenders();
+        $this->assertRequestSent('GET', '/marketing/v1/newsletters/senders');
+
+        $this->sdk->marketing()->updateSender(4, ['name' => 'S']);
+        $this->assertRequestSent('PATCH', '/marketing/v1/newsletters/senders/4', ['name' => 'S']);
+    }
+}


### PR DESCRIPTION
## Summary

Batch 4 of the JS-parity roadmap: **4 net-new growth / back-office services** (~54 methods), all additive, wired as connector accessors.

| Accessor | Service | Module |
| --- | --- | --- |
| `$sdk->marketing()` | `MarketingService` | `marketing/v1` |
| `$sdk->analytics()` | `AnalyticsService` | `analytics-backend/v1` (+ `crm/v1`) |
| `$sdk->automations()` | `AutomationsService` | `automations-backend/v1` |
| `$sdk->migrations()` | `MigrationsService` | import status/control |

## What's new

- **Marketing (30 methods)** — email templates (letters) CRUD + mass edit/delete, newsletters (mailings) CRUD + statistics/recipients/send/start/mass-send/mass-delete + credits, sending domains, and senders. Mass ops merge the filter params **into the body** (not query), matching the JS SDK exactly.
- **Analytics (11)** — reports & dashboards CRUD under `analytics-backend/v1`, plus `getFunnelConversion` which hits `/crm/v1/analytics/funnels`.
- **Automations (8)** — automations (`workers`) and workflows (`processes`) — list/create/update/delete/toggle.
- **Migrations (5)** — import status & control: `getAllSystemsStatus`, `getSystemProgress`, `getMondayProgress`, `getDataPresence`, `stopImport` (trello vs default routing preserved).

## Scope note: Migrations

Only the **status/control** subset is included. The per-system entity `calculate`/`import` methods (bitrix24, amo, …) branch across several ad-hoc gateway paths per system in the JS SDK and don't port cleanly to a single-base-URL server SDK, so they're intentionally omitted (documented in the class docblock). Can add later with an explicit host/route mapping.

## Tests

**+8 tests → 101 total, 216 assertions**, all offline via Saloon `MockClient`, asserting method + endpoint + body + query (incl. the mass-ops-merge-params-into-body behavior and the trello-vs-default stop routing).

## Verification

- ✅ `composer test` → OK (101 tests, 216 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

> Note: branched off `main` while batch 3 (#91) is still open. Both touch the connector's accessor list; a trivial merge may be needed depending on merge order.

## Roadmap remaining

5. Collaboration deepening: Emails 5→26, Comments 1→9, Departments/Groups/Files gaps
6. Misc: AIService, AppsService, ReindexService, AnnouncersService

🤖 Generated with [Claude Code](https://claude.com/claude-code)