### PR TITLE
Typed DTO layer: CRM entities + fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Most methods return a raw `Saloon\Http\Response`. Selected services return
 
 - **Auth** — `applicationSignIn()` / `refreshToken()` return a `Tokens` DTO.
 - **Users** — see the [Users service guide](docs/users.md).
+- **CRM entities** — see the [CRM service guide](docs/crm.md).
 
 Every output DTO keeps the **full raw payload**, so portal-specific **custom
 fields are never dropped**. Read them with `get()` / `has()`:
@@ -60,6 +61,7 @@ $user->raw;                    // the complete, untouched API payload
 ### Service guides
 
 - [Users](docs/users.md) — full DTO reference and examples.
+- [CRM entities](docs/crm.md) — entity + field DTOs, custom fields.
 
 ## Architecture
 

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -1,0 +1,102 @@
+# CRM entities
+
+CRM entities (deals, leads, contacts, companies, …) are almost entirely made of
+**portal-specific custom fields** — the API guarantees only `id`. So `EntityDTO`
+types `id` and exposes everything else (including custom fields) via `get()` /
+`has()` and the full `raw` payload.
+
+Two ways in:
+
+- `$sdk->crmDeals()` / `crmLeads()` / `crmContacts()` / `crmCompanies()` —
+  entity-scoped `CrmEntityService`.
+- `$sdk->crm()` — the generic `CrmService` (pass the entity type as a string).
+
+```php
+use Uspacy\SDK\Http\Client\UspacySDK;
+
+$sdk = new UspacySDK('https://acme.uspacy.ua', $accessToken);
+```
+
+## Entities
+
+```php
+// List -> Collection<EntityDTO>
+$page = $sdk->crmDeals()->getEntities(['page' => 1, 'list' => 20]);
+foreach ($page->data as $deal) {
+    $deal->id;                  // typed
+    $deal->get('title');        // any standard field
+    $deal->get('customfield_1'); // custom field (or null)
+}
+$page->meta->total;
+
+// generic service equivalent
+$sdk->crm()->getDeals(['page' => 1]);      // Collection<EntityDTO>
+$sdk->crm()->getEntities('deals', []);     // Collection<EntityDTO>
+
+// Single writes -> EntityDTO
+$deal = $sdk->crmDeals()->createEntity(['title' => 'New deal', 'customfield_1' => 'x']);
+$deal->id;
+$deal->get('customfield_1');
+
+$sdk->crmDeals()->updateEntity(42, ['title' => 'Renamed']);         // EntityDTO
+$sdk->crmDeals()->moveFromStageToStage(42, 9, reasonId: 3);          // EntityDTO
+$sdk->crmDeals()->getByStage(9);                                     // Collection<EntityDTO>
+
+// Deletes / mass ops return the raw Response
+$sdk->crmDeals()->deleteEntity(42);
+$sdk->crmDeals()->massDeletion(entityIds: [1, 2, 3]);
+$sdk->crmDeals()->massEditing(payload: ['customfield_1' => 'y'], entityIds: [1, 2]);
+```
+
+### Custom fields
+
+Every `EntityDTO` keeps the complete payload, so custom fields are never lost:
+
+```php
+$deal = $sdk->crmDeals()->getEntities()->data[0];
+
+$deal->has('customfield_2');            // true / false
+$deal->get('customfield_2');            // value or null
+$deal->get('customfield_2', 'default'); // value or default
+$deal->raw;                             // the complete, untouched API payload
+```
+
+## Fields
+
+```php
+// List -> FieldDTO[]
+$fields = $sdk->crmDeals()->getFields();
+foreach ($fields as $field) {
+    $field->code;        // 'title'
+    $field->type;        // 'string'
+    $field->required;    // bool
+    $field->values;      // list values for dropdowns
+    $field->get('sort'); // any other IField property
+}
+
+// generic service
+$sdk->crm()->getFields('deals');            // FieldDTO[]
+$sdk->crm()->getField('deals', 'amount');   // FieldDTO
+
+// create / update -> FieldDTO
+$sdk->crmDeals()->createField(['name' => 'Priority', 'code' => 'priority', 'type' => 'list']);
+$sdk->crmDeals()->updateField('priority', ['name' => 'Priority level']);
+
+// delete + list-value ops return raw Response
+$sdk->crmDeals()->deleteField('priority');
+$sdk->crmDeals()->updateListValues('priority', [['value' => 'High']]);
+$sdk->crmDeals()->deleteListValue('priority', 'value-id');
+```
+
+## Return-type reference (CrmEntityService + generic CrmService)
+
+| Method | Returns |
+| --- | --- |
+| `getEntities`, `getByStage`, `getContacts/Companies/Leads/Deals` | `Collection<EntityDTO>` |
+| `createEntity`, `updateEntity`, `patchEntity`, `moveFromStageToStage`, `create{Contact,Company,Lead,Deal}` | `EntityDTO` |
+| `getFields` | `FieldDTO[]` |
+| `getField`, `createField`, `updateField` | `FieldDTO` |
+| `deleteEntity`, `massDeletion`, `massEditing`, `massEditEntities`, `deleteField`, `updateListValues`, `deleteListValue` | `Saloon\Http\Response` |
+
+> Funnels, stages, products, catalog, requisites and document templates are typed
+> with the same ruleset in follow-up work.

--- a/src/DTOs/Crm/EntityDTO.php
+++ b/src/DTOs/Crm/EntityDTO.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM entity record (deal, lead, contact, company, product, ...).
+ *
+ * CRM entities are almost entirely portal-specific custom fields — the API model
+ * guarantees only `id`. So only `id` is typed; read every other field (including
+ * custom fields) with {@see get()} / {@see has()} or via {@see $raw}, e.g.
+ * `$entity->get('title')`, `$entity->get('customfield_1')`.
+ */
+final class EntityDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/FieldDTO.php
+++ b/src/DTOs/Crm/FieldDTO.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM field definition (mirrors the JS `IField`).
+ *
+ * Documented fields are typed; the full payload is retained in {@see $raw} and
+ * reachable via {@see get()} / {@see has()}.
+ */
+final class FieldDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?string $name,
+        public readonly ?string $code,
+        public readonly ?string $type,
+        public readonly ?bool $required,
+        public readonly ?bool $editable,
+        public readonly ?bool $show,
+        public readonly ?bool $hidden,
+        public readonly ?bool $multiple,
+        public readonly ?bool $systemField,
+        public readonly array $values,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'] ?? null,
+            code: $data['code'] ?? null,
+            type: $data['type'] ?? null,
+            required: $data['required'] ?? null,
+            editable: $data['editable'] ?? null,
+            show: $data['show'] ?? null,
+            hidden: $data['hidden'] ?? null,
+            multiple: $data['multiple'] ?? null,
+            systemField: $data['system_field'] ?? null,
+            values: $data['values'] ?? [],
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/CrmEntityService.php
+++ b/src/Services/CrmEntityService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\EntityDTO;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
 use Uspacy\SDK\Http\Client\HttpClient;
 
 /**
@@ -26,18 +29,22 @@ class CrmEntityService extends Service
      * Get a page of entities.
      *
      * @param  array  $params  query parameters (page, list, filters, ...)
+     * @return Collection<EntityDTO>
      */
-    public function getEntities(array $params = []): Response
+    public function getEntities(array $params = []): Collection
     {
-        return $this->http->get($this->namespace(), $params);
+        return Collection::fromArray(
+            $this->http->get($this->namespace(), $params)->json() ?? [],
+            [EntityDTO::class, 'fromArray'],
+        );
     }
 
     /**
      * Create an entity.
      */
-    public function createEntity(array $data): Response
+    public function createEntity(array $data): EntityDTO
     {
-        return $this->http->post($this->namespace(), $data);
+        return EntityDTO::fromArray($this->http->post($this->namespace(), $data)->json() ?? []);
     }
 
     /**
@@ -45,9 +52,9 @@ class CrmEntityService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateEntity($id, array $data): Response
+    public function updateEntity($id, array $data): EntityDTO
     {
-        return $this->http->patch($this->namespace() . "/{$id}", $data);
+        return EntityDTO::fromArray($this->http->patch($this->namespace() . "/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -100,26 +107,30 @@ class CrmEntityService extends Service
 
     /**
      * Get the fields of this entity type.
+     *
+     * @return array<int, FieldDTO>
      */
-    public function getFields(): Response
+    public function getFields(): array
     {
-        return $this->http->get($this->namespace() . '/fields');
+        $data = $this->http->get($this->namespace() . '/fields')->json() ?? [];
+
+        return array_map([FieldDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a field.
      */
-    public function createField(array $data): Response
+    public function createField(array $data): FieldDTO
     {
-        return $this->http->post($this->namespace() . '/fields', $data);
+        return FieldDTO::fromArray($this->http->post($this->namespace() . '/fields', $data)->json() ?? []);
     }
 
     /**
      * Update a field by its code.
      */
-    public function updateField(string $code, array $data): Response
+    public function updateField(string $code, array $data): FieldDTO
     {
-        return $this->http->patch($this->namespace() . "/fields/{$code}", $data);
+        return FieldDTO::fromArray($this->http->patch($this->namespace() . "/fields/{$code}", $data)->json() ?? []);
     }
 
     /**
@@ -152,10 +163,14 @@ class CrmEntityService extends Service
      * Get entities that belong to a kanban stage.
      *
      * @param  int|string  $stageId
+     * @return Collection<EntityDTO>
      */
-    public function getByStage($stageId): Response
+    public function getByStage($stageId): Collection
     {
-        return $this->http->get($this->namespace() . "/kanban/stage/{$stageId}");
+        return Collection::fromArray(
+            $this->http->get($this->namespace() . "/kanban/stage/{$stageId}")->json() ?? [],
+            [EntityDTO::class, 'fromArray'],
+        );
     }
 
     /**
@@ -165,12 +180,12 @@ class CrmEntityService extends Service
      * @param  int|string  $stageId
      * @param  int|string|null  $reasonId  fail reason id, when the target stage requires one
      */
-    public function moveFromStageToStage($entityId, $stageId, $reasonId = null): Response
+    public function moveFromStageToStage($entityId, $stageId, $reasonId = null): EntityDTO
     {
-        return $this->http->post(
+        return EntityDTO::fromArray($this->http->post(
             $this->namespace() . "/{$entityId}/move/stage/{$stageId}",
             ['reason_id' => $reasonId],
-        );
+        )->json() ?? []);
     }
 
     private function namespace(): string

--- a/src/Services/CrmService.php
+++ b/src/Services/CrmService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\EntityDTO;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
 
 /**
  * CRM service.
@@ -29,27 +32,45 @@ class CrmService extends Service
      * @param  string  $entityType  e.g. contacts, companies, leads, deals or a custom type
      * @param  array  $params  query parameters (page, list, filters, ...)
      */
-    public function getEntities(string $entityType, array $params = []): Response
+    /**
+     * @return Collection<EntityDTO>
+     */
+    public function getEntities(string $entityType, array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/", $params);
+        return Collection::fromArray(
+            $this->http->get(self::NAMESPACE . "/entities/{$entityType}/", $params)->json() ?? [],
+            [EntityDTO::class, 'fromArray'],
+        );
     }
 
-    public function getContacts(array $params = []): Response
+    /**
+     * @return Collection<EntityDTO>
+     */
+    public function getContacts(array $params = []): Collection
     {
         return $this->getEntities('contacts', $params);
     }
 
-    public function getCompanies(array $params = []): Response
+    /**
+     * @return Collection<EntityDTO>
+     */
+    public function getCompanies(array $params = []): Collection
     {
         return $this->getEntities('companies', $params);
     }
 
-    public function getLeads(array $params = []): Response
+    /**
+     * @return Collection<EntityDTO>
+     */
+    public function getLeads(array $params = []): Collection
     {
         return $this->getEntities('leads', $params);
     }
 
-    public function getDeals(array $params = []): Response
+    /**
+     * @return Collection<EntityDTO>
+     */
+    public function getDeals(array $params = []): Collection
     {
         return $this->getEntities('deals', $params);
     }
@@ -57,27 +78,27 @@ class CrmService extends Service
     /**
      * Create an entity of the given type.
      */
-    public function createEntity(string $entityType, array $data): Response
+    public function createEntity(string $entityType, array $data): EntityDTO
     {
-        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/", $data);
+        return EntityDTO::fromArray($this->http->post(self::NAMESPACE . "/entities/{$entityType}/", $data)->json() ?? []);
     }
 
-    public function createContact(array $data): Response
+    public function createContact(array $data): EntityDTO
     {
         return $this->createEntity('contacts', $data);
     }
 
-    public function createCompany(array $data): Response
+    public function createCompany(array $data): EntityDTO
     {
         return $this->createEntity('companies', $data);
     }
 
-    public function createLead(array $data): Response
+    public function createLead(array $data): EntityDTO
     {
         return $this->createEntity('leads', $data);
     }
 
-    public function createDeal(array $data): Response
+    public function createDeal(array $data): EntityDTO
     {
         return $this->createEntity('deals', $data);
     }
@@ -87,9 +108,9 @@ class CrmService extends Service
      *
      * @param  int|string  $id
      */
-    public function patchEntity(string $entityType, $id, array $data): Response
+    public function patchEntity(string $entityType, $id, array $data): EntityDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/entities/{$entityType}/{$id}", $data);
+        return EntityDTO::fromArray($this->http->patch(self::NAMESPACE . "/entities/{$entityType}/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -102,26 +123,34 @@ class CrmService extends Service
 
     /**
      * Get all fields for an entity type.
+     *
+     * @return array<int, FieldDTO>
      */
-    public function getFields(string $entityType): Response
+    public function getFields(string $entityType): array
     {
-        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields");
+        $data = $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields")->json() ?? [];
+
+        return array_map([FieldDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Get a single field definition by its type/code.
      */
-    public function getField(string $entityType, string $fieldType): Response
+    public function getField(string $entityType, string $fieldType): FieldDTO
     {
-        return $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldType}");
+        return FieldDTO::fromArray(
+            $this->http->get(self::NAMESPACE . "/entities/{$entityType}/fields/{$fieldType}")->json() ?? [],
+        );
     }
 
     /**
      * Create a field for an entity type.
      */
-    public function createField(string $entityType, array $data): Response
+    public function createField(string $entityType, array $data): FieldDTO
     {
-        return $this->http->post(self::NAMESPACE . "/entities/{$entityType}/fields", $data);
+        return FieldDTO::fromArray(
+            $this->http->post(self::NAMESPACE . "/entities/{$entityType}/fields", $data)->json() ?? [],
+        );
     }
 
     /**

--- a/tests/Services/CrmDtoTest.php
+++ b/tests/Services/CrmDtoTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\EntityDTO;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmDtoTest extends TestCase
+{
+    public function test_get_entities_hydrates_collection_of_entity_dtos(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['id' => 1, 'title' => 'Deal A', 'customfield_1' => 'x'],
+                ['id' => 2, 'title' => 'Deal B'],
+            ],
+            'meta' => ['total' => 2, 'page' => 1],
+        ]);
+
+        $result = $this->sdk->crmDeals()->getEntities(['page' => 1]);
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertInstanceOf(EntityDTO::class, $result->data[0]);
+        $this->assertSame(1, $result->data[0]->id);
+        $this->assertSame(2, $result->meta->total);
+    }
+
+    public function test_entity_custom_fields_via_get_has(): void
+    {
+        $this->mockGet(['id' => 5, 'title' => 'Deal', 'customfield_1' => 'value', 'customfield_2' => 99]);
+
+        // create returns a single entity
+        $this->sdk->withMockClient(new MockClient([
+            PostRequest::class => MockResponse::make(['id' => 5, 'title' => 'Deal', 'customfield_1' => 'value'], 201),
+        ]));
+        $entity = $this->sdk->crmDeals()->createEntity(['title' => 'Deal']);
+
+        $this->assertInstanceOf(EntityDTO::class, $entity);
+        $this->assertSame(5, $entity->id);
+        $this->assertTrue($entity->has('customfield_1'));
+        $this->assertSame('value', $entity->get('customfield_1'));
+        $this->assertSame('Deal', $entity->get('title'));
+        $this->assertNull($entity->get('customfield_404'));
+    }
+
+    public function test_get_fields_hydrates_field_dtos_from_data_envelope(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['name' => 'Title', 'code' => 'title', 'type' => 'string', 'required' => true, 'system_field' => true],
+                ['name' => 'Amount', 'code' => 'amount', 'type' => 'number', 'multiple' => false],
+            ],
+        ]);
+
+        $fields = $this->sdk->crmDeals()->getFields();
+
+        $this->assertIsArray($fields);
+        $this->assertCount(2, $fields);
+        $this->assertInstanceOf(FieldDTO::class, $fields[0]);
+        $this->assertSame('title', $fields[0]->code);
+        $this->assertSame('string', $fields[0]->type);
+        $this->assertTrue($fields[0]->required);
+        $this->assertTrue($fields[0]->systemField);
+    }
+
+    public function test_generic_crm_service_also_returns_dtos(): void
+    {
+        $this->mockGet([
+            'data' => [['id' => 7, 'title' => 'C']],
+            'meta' => ['total' => 1],
+        ]);
+
+        $result = $this->sdk->crm()->getDeals();
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(7, $result->data[0]->id);
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $entity = $this->sdk->crmDeals()->getByStage(3);
+        $this->assertInstanceOf(Collection::class, $entity);
+        $this->assertSame([], $entity->data);
+
+        $this->assertSame([], $this->sdk->crmDeals()->getFields());
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the typed DTO layer (after #93) for **CRM entities and fields**, using the approved per-pattern ruleset. Covers `CrmEntityService` (deals/leads/contacts/companies) and the generic `CrmService` entity/field methods.

## DTOs

- **`EntityDTO`** — CRM entities are almost entirely portal-specific custom fields (the API model guarantees only `id`). So `id` is typed and everything else — standard *and* custom fields — is read via `get()` / `has()` / `raw`.
- **`FieldDTO`** — typed `IField` fields (`name`, `code`, `type`, `required`, `editable`, `multiple`, `values`, `system_field`, …) + `raw`.

## Ruleset applied

| Pattern | Returns |
| --- | --- |
| get single / create / update / move | `EntityDTO` |
| entity list / `getByStage` | `Collection<EntityDTO>` |
| `getFields` | `FieldDTO[]` (hydrated from the `{ data: [...] }` envelope) |
| `getField` / create / update field | `FieldDTO` |
| delete / mass ops / list-value ops | raw `Response` |

All `->json()` hydration is null-safe (`?? []`).

## Docs

- New **`docs/crm.md`** (entity + field DTOs, custom fields via `get()/has()`, return-type table), linked from the README.

## Tests

**+5 tests → 129 total, 323 assertions.** New `CrmDtoTest` proves entity/collection/field hydration, custom fields via `get()/has()`, the generic `CrmService` returning DTOs, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (129 tests, 323 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

## Follow-ups

Same ruleset rolls across the remaining CRM services (funnels, stages, products, catalog, requisites, document templates) in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)