### PR TITLE
Typed DTO layer: CRM funnels + stages + reasons

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -98,5 +98,57 @@ $sdk->crmDeals()->deleteListValue('priority', 'value-id');
 | `getField`, `createField`, `updateField` | `FieldDTO` |
 | `deleteEntity`, `massDeletion`, `massEditing`, `massEditEntities`, `deleteField`, `updateListValues`, `deleteListValue` | `Saloon\Http\Response` |
 
-> Funnels, stages, products, catalog, requisites and document templates are typed
-> with the same ruleset in follow-up work.
+## Funnels, stages & reasons
+
+`$sdk->crmDealsFunnels()` / `crmLeadsFunnels()` (`CrmFunnelsService`) and
+`$sdk->crmDealsStages()` / `crmLeadsStages()` (`CrmStagesService`) return typed
+funnel/stage/reason DTOs. Nested collections are hydrated too, so a funnel's
+stages and a stage's reasons are typed all the way down.
+
+```php
+// Funnels -> FunnelDTO[] (with nested stages)
+$funnels = $sdk->crmDealsFunnels()->getFunnels();
+$funnels[0]->title;
+$funnels[0]->funnelCode;
+$funnels[0]->isDefault;               // bool (API field: default)
+$funnels[0]->stages[0]->stageCode;    // nested StageDTO
+
+$sdk->crmDealsFunnels()->createFunnel(['title' => 'Sales']);   // FunnelDTO
+$sdk->crmDealsFunnels()->updateFunnel(3, ['title' => 'B2B']);  // FunnelDTO
+$sdk->crmDealsFunnels()->deleteFunnel(3);                      // raw Response
+
+// Stages -> StageDTO[]
+$stages = $sdk->crmDealsStages()->getStages();
+$stages[0]->stageCode;
+$stages[0]->color;
+$stages[0]->reasons;                  // nested ReasonDTO[]
+$sdk->crmDealsFunnels()->getStagesByFunnel(3);                 // StageDTO[]
+
+$sdk->crmDealsStages()->createStage(['title' => 'New']);       // StageDTO
+$sdk->crmDealsStages()->updateStage(10, ['color' => '#fff']);  // StageDTO
+$sdk->crmDealsStages()->deleteStage(10);                       // raw Response
+
+// Reasons -> ReasonsDTO (grouped success / fail)
+$reasons = $sdk->crmDealsStages()->getReasons(42);
+$reasons->success;   // ReasonDTO[]
+$reasons->fail;      // ReasonDTO[]
+
+$sdk->crmDealsStages()->createReason(42, ['title' => 'Won']);  // ReasonDTO
+$sdk->crmDealsFunnels()->createStageReason(3, ['title' => 'Lost']); // ReasonDTO
+$sdk->crmDealsStages()->deleteReason(9);                       // raw Response
+```
+
+### Return-type reference (funnels & stages)
+
+| Method | Returns |
+| --- | --- |
+| `getFunnels` | `FunnelDTO[]` |
+| `createFunnel`, `updateFunnel` | `FunnelDTO` |
+| `getStages`, `getStagesByFunnel` | `StageDTO[]` |
+| `createStage`, `updateStage` | `StageDTO` |
+| `getReasons` | `ReasonsDTO` (grouped `success` / `fail`) |
+| `createReason`, `updateReason`, `createStageReason`, `updateStageReason` | `ReasonDTO` |
+| `deleteFunnel`, `deleteStage`, `deleteReason`, `deleteStageReason` | `Saloon\Http\Response` |
+
+> Products, catalog, requisites and document templates are typed with the same
+> ruleset in follow-up work.

--- a/src/DTOs/Crm/FunnelDTO.php
+++ b/src/DTOs/Crm/FunnelDTO.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM funnel (mirrors the JS `IFunnel`).
+ *
+ * Documented fields are typed; the full payload is retained in {@see $raw}.
+ */
+final class FunnelDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, StageDTO>  $stages
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly ?string $funnelCode,
+        public readonly ?bool $isDefault,
+        public readonly ?bool $active,
+        public readonly ?bool $tariffLimited,
+        public readonly array $stages,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            funnelCode: $data['funnel_code'] ?? null,
+            isDefault: $data['default'] ?? null,
+            active: $data['active'] ?? null,
+            tariffLimited: $data['tariff_limited'] ?? null,
+            stages: array_map([StageDTO::class, 'fromArray'], $data['stages'] ?? []),
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/ReasonDTO.php
+++ b/src/DTOs/Crm/ReasonDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM kanban stage fail/success reason (mirrors the JS `IReason`).
+ */
+final class ReasonDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly ?int $sort,
+        public readonly ?int $funnelId,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            sort: $data['sort'] ?? null,
+            funnelId: $data['funnel_id'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/ReasonsDTO.php
+++ b/src/DTOs/Crm/ReasonsDTO.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * Grouped kanban stage reasons (mirrors the JS `IReasons`: `{ SUCCESS, FAIL }`).
+ */
+final class ReasonsDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, ReasonDTO>  $success
+     * @param  array<int, ReasonDTO>  $fail
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly array $success,
+        public readonly array $fail,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            success: array_map([ReasonDTO::class, 'fromArray'], $data['SUCCESS'] ?? []),
+            fail: array_map([ReasonDTO::class, 'fromArray'], $data['FAIL'] ?? []),
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/StageDTO.php
+++ b/src/DTOs/Crm/StageDTO.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM kanban stage (mirrors the JS `IStage`).
+ *
+ * Documented fields are typed; the full payload is retained in {@see $raw}.
+ */
+final class StageDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, ReasonDTO>  $reasons
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly ?string $stageCode,
+        public readonly ?string $color,
+        public readonly ?int $sort,
+        public readonly ?bool $systemStage,
+        public readonly ?int $funnelId,
+        public readonly array $reasons,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            stageCode: $data['stage_code'] ?? null,
+            color: $data['color'] ?? null,
+            sort: $data['sort'] ?? null,
+            systemStage: $data['system_stage'] ?? null,
+            funnelId: $data['funnel_id'] ?? null,
+            reasons: array_map([ReasonDTO::class, 'fromArray'], $data['reasons'] ?? []),
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/CrmFunnelsService.php
+++ b/src/Services/CrmFunnelsService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\FunnelDTO;
+use Uspacy\SDK\DTOs\Crm\ReasonDTO;
+use Uspacy\SDK\DTOs\Crm\StageDTO;
 use Uspacy\SDK\Http\Client\HttpClient;
 
 /**
@@ -24,18 +27,22 @@ class CrmFunnelsService extends Service
 
     /**
      * Get all funnels for this entity type.
+     *
+     * @return array<int, FunnelDTO>
      */
-    public function getFunnels(): Response
+    public function getFunnels(): array
     {
-        return $this->http->get($this->namespace() . '/funnel');
+        $data = $this->http->get($this->namespace() . '/funnel')->json() ?? [];
+
+        return array_map([FunnelDTO::class, 'fromArray'], $data);
     }
 
     /**
      * Create a funnel.
      */
-    public function createFunnel(array $data): Response
+    public function createFunnel(array $data): FunnelDTO
     {
-        return $this->http->post($this->namespace() . '/funnel', $data);
+        return FunnelDTO::fromArray($this->http->post($this->namespace() . '/funnel', $data)->json() ?? []);
     }
 
     /**
@@ -43,9 +50,9 @@ class CrmFunnelsService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateFunnel($id, array $data): Response
+    public function updateFunnel($id, array $data): FunnelDTO
     {
-        return $this->http->patch($this->namespace() . "/funnel/{$id}", $data);
+        return FunnelDTO::fromArray($this->http->patch($this->namespace() . "/funnel/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -62,18 +69,21 @@ class CrmFunnelsService extends Service
      * Get the kanban stages of a specific funnel.
      *
      * @param  int|string  $funnelId
+     * @return array<int, StageDTO>
      */
-    public function getStagesByFunnel($funnelId): Response
+    public function getStagesByFunnel($funnelId): array
     {
-        return $this->http->get($this->namespace() . '/kanban/stage', ['funnel_id' => $funnelId]);
+        $data = $this->http->get($this->namespace() . '/kanban/stage', ['funnel_id' => $funnelId])->json() ?? [];
+
+        return array_map([StageDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a kanban stage for a funnel.
      */
-    public function createStage(array $data): Response
+    public function createStage(array $data): StageDTO
     {
-        return $this->http->post($this->namespace() . '/kanban/stage', $data);
+        return StageDTO::fromArray($this->http->post($this->namespace() . '/kanban/stage', $data)->json() ?? []);
     }
 
     /**
@@ -81,9 +91,9 @@ class CrmFunnelsService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateStage($id, array $data): Response
+    public function updateStage($id, array $data): StageDTO
     {
-        return $this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data);
+        return StageDTO::fromArray($this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -101,9 +111,9 @@ class CrmFunnelsService extends Service
      *
      * @param  int|string  $funnelId
      */
-    public function createStageReason($funnelId, array $data): Response
+    public function createStageReason($funnelId, array $data): ReasonDTO
     {
-        return $this->http->post(self::REASONS_NAMESPACE . "/{$funnelId}", $data);
+        return ReasonDTO::fromArray($this->http->post(self::REASONS_NAMESPACE . "/{$funnelId}", $data)->json() ?? []);
     }
 
     /**
@@ -111,9 +121,9 @@ class CrmFunnelsService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateStageReason($id, array $data): Response
+    public function updateStageReason($id, array $data): ReasonDTO
     {
-        return $this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data);
+        return ReasonDTO::fromArray($this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmStagesService.php
+++ b/src/Services/CrmStagesService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\ReasonDTO;
+use Uspacy\SDK\DTOs\Crm\ReasonsDTO;
+use Uspacy\SDK\DTOs\Crm\StageDTO;
 use Uspacy\SDK\Http\Client\HttpClient;
 
 /**
@@ -24,18 +27,22 @@ class CrmStagesService extends Service
 
     /**
      * Get all kanban stages for this entity type.
+     *
+     * @return array<int, StageDTO>
      */
-    public function getStages(): Response
+    public function getStages(): array
     {
-        return $this->http->get($this->namespace() . '/kanban/stage');
+        $data = $this->http->get($this->namespace() . '/kanban/stage')->json() ?? [];
+
+        return array_map([StageDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a kanban stage.
      */
-    public function createStage(array $data): Response
+    public function createStage(array $data): StageDTO
     {
-        return $this->http->post($this->namespace() . '/kanban/stage', $data);
+        return StageDTO::fromArray($this->http->post($this->namespace() . '/kanban/stage', $data)->json() ?? []);
     }
 
     /**
@@ -43,9 +50,9 @@ class CrmStagesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateStage($id, array $data): Response
+    public function updateStage($id, array $data): StageDTO
     {
-        return $this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data);
+        return StageDTO::fromArray($this->http->patch($this->namespace() . "/kanban/stage/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -63,9 +70,9 @@ class CrmStagesService extends Service
      *
      * @param  int|string  $entityId
      */
-    public function getReasons($entityId): Response
+    public function getReasons($entityId): ReasonsDTO
     {
-        return $this->http->get(self::REASONS_NAMESPACE . "/{$entityId}");
+        return ReasonsDTO::fromArray($this->http->get(self::REASONS_NAMESPACE . "/{$entityId}")->json() ?? []);
     }
 
     /**
@@ -73,9 +80,9 @@ class CrmStagesService extends Service
      *
      * @param  int|string  $entityId
      */
-    public function createReason($entityId, array $data): Response
+    public function createReason($entityId, array $data): ReasonDTO
     {
-        return $this->http->post(self::REASONS_NAMESPACE . "/{$entityId}", $data);
+        return ReasonDTO::fromArray($this->http->post(self::REASONS_NAMESPACE . "/{$entityId}", $data)->json() ?? []);
     }
 
     /**
@@ -83,9 +90,9 @@ class CrmStagesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateReason($id, array $data): Response
+    public function updateReason($id, array $data): ReasonDTO
     {
-        return $this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data);
+        return ReasonDTO::fromArray($this->http->patch(self::REASONS_NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/tests/Services/CrmFunnelsDtoTest.php
+++ b/tests/Services/CrmFunnelsDtoTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Crm\FunnelDTO;
+use Uspacy\SDK\DTOs\Crm\ReasonDTO;
+use Uspacy\SDK\DTOs\Crm\ReasonsDTO;
+use Uspacy\SDK\DTOs\Crm\StageDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmFunnelsDtoTest extends TestCase
+{
+    public function test_get_funnels_hydrates_funnel_dtos_with_nested_stages(): void
+    {
+        $this->mockGet([
+            [
+                'id' => 1,
+                'title' => 'Sales',
+                'funnel_code' => 'sales',
+                'default' => true,
+                'active' => true,
+                'tariff_limited' => false,
+                'stages' => [
+                    ['id' => 10, 'title' => 'New', 'stage_code' => 'new', 'system_stage' => true],
+                ],
+            ],
+        ]);
+
+        $funnels = $this->sdk->crmDealsFunnels()->getFunnels();
+
+        $this->assertIsArray($funnels);
+        $this->assertInstanceOf(FunnelDTO::class, $funnels[0]);
+        $this->assertSame('sales', $funnels[0]->funnelCode);
+        $this->assertTrue($funnels[0]->isDefault);
+        $this->assertInstanceOf(StageDTO::class, $funnels[0]->stages[0]);
+        $this->assertSame('new', $funnels[0]->stages[0]->stageCode);
+    }
+
+    public function test_get_stages_hydrates_from_data_envelope(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['id' => 10, 'title' => 'New', 'stage_code' => 'new', 'color' => '#fff', 'sort' => 1, 'system_stage' => false],
+                ['id' => 11, 'title' => 'Won', 'stage_code' => 'won'],
+            ],
+        ]);
+
+        $stages = $this->sdk->crmDealsStages()->getStages();
+
+        $this->assertCount(2, $stages);
+        $this->assertInstanceOf(StageDTO::class, $stages[0]);
+        $this->assertSame('new', $stages[0]->stageCode);
+        $this->assertSame('#fff', $stages[0]->color);
+    }
+
+    public function test_get_reasons_hydrates_grouped_success_fail(): void
+    {
+        $this->mockGet([
+            'SUCCESS' => [['id' => 1, 'title' => 'Won deal', 'sort' => 1]],
+            'FAIL' => [['id' => 2, 'title' => 'Too expensive'], ['id' => 3, 'title' => 'No budget']],
+        ]);
+
+        $reasons = $this->sdk->crmDealsStages()->getReasons(42);
+
+        $this->assertInstanceOf(ReasonsDTO::class, $reasons);
+        $this->assertCount(1, $reasons->success);
+        $this->assertCount(2, $reasons->fail);
+        $this->assertInstanceOf(ReasonDTO::class, $reasons->success[0]);
+        $this->assertSame('Won deal', $reasons->success[0]->title);
+        $this->assertSame('No budget', $reasons->fail[1]->title);
+    }
+
+    public function test_stage_custom_fields_via_get_has(): void
+    {
+        $this->mockGet(['data' => [['id' => 10, 'title' => 'New', 'customfield_1' => 'x']]]);
+
+        $stage = $this->sdk->crmDealsStages()->getStages()[0];
+
+        $this->assertTrue($stage->has('customfield_1'));
+        $this->assertSame('x', $stage->get('customfield_1'));
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $this->assertSame([], $this->sdk->crmDealsFunnels()->getFunnels());
+        $this->assertSame([], $this->sdk->crmDealsStages()->getStages());
+
+        $reasons = $this->sdk->crmDealsStages()->getReasons(1);
+        $this->assertSame([], $reasons->success);
+        $this->assertSame([], $reasons->fail);
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the typed DTO layer for **CRM funnels, stages and reasons**, using the approved per-pattern ruleset. Covers `CrmFunnelsService` and `CrmStagesService` (both parameterized for deals/leads).

Independent of #94 (entities/fields) — branched off `main`.

## DTOs

All type their documented fields, keep the full `raw`, and support `get()` / `has()`:

- **`FunnelDTO`** (`IFunnel`) — id, title, funnelCode, isDefault, active, tariffLimited, nested `stages: StageDTO[]`.
- **`StageDTO`** (`IStage`) — id, title, stageCode, color, sort, systemStage, funnelId, nested `reasons: ReasonDTO[]`.
- **`ReasonDTO`** (`IReason`) — id, title, sort, funnelId.
- **`ReasonsDTO`** — grouped `{ success, fail }`, mirroring the JS `IReasons` (`{ SUCCESS, FAIL }`).

## Ruleset applied

| Method | Returns |
| --- | --- |
| `getFunnels` | `FunnelDTO[]` |
| `createFunnel`, `updateFunnel` | `FunnelDTO` |
| `getStages`, `getStagesByFunnel` | `StageDTO[]` (from the `{ data }` envelope) |
| `createStage`, `updateStage` | `StageDTO` |
| `getReasons` | `ReasonsDTO` (grouped success/fail) |
| `createReason`, `updateReason`, `createStageReason`, `updateStageReason` | `ReasonDTO` |
| delete funnel / stage / reason | raw `Response` |

All `->json()` hydration is null-safe (`?? []`).

## Tests

**+5 tests → 134 total, 345 assertions.** New `CrmFunnelsDtoTest` proves funnel hydration with nested stages, stages from the data envelope, the grouped success/fail reasons, custom fields via `get()/has()`, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (134 tests, 345 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

## Follow-ups

`docs/crm.md` (added in #94) will be extended with a funnels/stages section once #94 merges. Remaining CRM services (products, catalog, requisites, document templates) follow with the same ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)