### PR TITLE
Typed DTO layer: CRM products + catalog

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -150,5 +150,62 @@ $sdk->crmDealsStages()->deleteReason(9);                       // raw Response
 | `createReason`, `updateReason`, `createStageReason`, `updateStageReason` | `ReasonDTO` |
 | `deleteFunnel`, `deleteStage`, `deleteReason`, `deleteStageReason` | `Saloon\Http\Response` |
 
-> Products, catalog, requisites and document templates are typed with the same
-> ruleset in follow-up work.
+## Products & catalog
+
+```php
+// Products -> Collection<ProductDTO>
+$page = $sdk->crmProducts()->getProducts(['page' => 1]);
+$page->data[0]->title;
+$page->data[0]->isActive;
+$page->data[0]->get('customfield_1');   // products carry custom fields too
+
+$sdk->crmProducts()->createProduct(['title' => 'Widget']);   // ProductDTO
+$sdk->crmProducts()->updateProduct(3, ['title' => 'Widget2']); // ProductDTO
+$sdk->crmProducts()->deleteProduct(3);                        // raw Response
+
+// Product fields -> FieldDTO[] (dynamic namespace)
+$sdk->crmProducts()->getFields();
+$sdk->crmProducts()->createField(['name' => 'Colour', 'code' => 'colour']); // FieldDTO
+
+// Catalog references -> DTO[]
+$sdk->crmProductsCategories()->getProductCategories(); // CategoryDTO[] (nested childCategories)
+$sdk->crmProductsUnits()->getProductUnits();           // UnitDTO[]
+$sdk->crmProductsTaxes()->getProductTaxes();           // TaxDTO[]
+$sdk->crmProductsPriceTypes()->getProductPriceTypes(); // PriceTypeDTO[]
+
+// each supports create/update -> DTO, delete -> raw Response
+$sdk->crmProductsTaxes()->createProductTax(['name' => 'VAT', 'rate' => 20]); // TaxDTO
+```
+
+### Line products (products attached to an entity)
+
+```php
+// Aggregated info -> ProductInfoForEntityDTO (nested listProducts)
+$info = $sdk->crmProductsForEntity()->getInfoProductsForEntity('deals', 42);
+$info->amountTotal;
+$info->listProducts[0]->title;   // nested ProductForEntityDTO
+
+// Line products
+$sdk->crmProductsForEntity()->getProductsForEntity();      // ProductForEntityDTO[]
+$sdk->crmProductsForEntity()->getProductForEntity(7);      // ProductForEntityDTO
+$sdk->crmProductsForEntity()->updateProductForEntity(7, ['quantity' => 3]); // ProductForEntityDTO
+$sdk->crmProductsForEntity()->createProductsForEntity([['product_id' => 1, 'quantity' => 2]]); // ProductForEntityDTO[]
+$sdk->crmProductsForEntity()->deleteProductsForEntity([1, 2]); // raw Response
+```
+
+### Return-type reference (products & catalog)
+
+| Method | Returns |
+| --- | --- |
+| `crmProducts()->getProducts` | `Collection<ProductDTO>` |
+| `crmProducts()->createProduct` / `updateProduct` | `ProductDTO` |
+| `crmProducts()->getFields` | `FieldDTO[]` |
+| `crmProducts()->createField` / `updateField` | `FieldDTO` |
+| `crmProductsCategories/Units/Taxes/PriceTypes()->get…` | `CategoryDTO[]` / `UnitDTO[]` / `TaxDTO[]` / `PriceTypeDTO[]` |
+| … `->create…` / `->update…` | the matching single DTO |
+| `crmProductsForEntity()->getInfoProductsForEntity` / `updateInfoProductForEntity` / `createProductForEntity` | `ProductInfoForEntityDTO` |
+| `crmProductsForEntity()->getProductForEntity` / `updateProductForEntity` | `ProductForEntityDTO` |
+| `crmProductsForEntity()->getProductsForEntity` / `create…` / `update…` (bulk) | `ProductForEntityDTO[]` |
+| all delete / mass / list-value methods | `Saloon\Http\Response` |
+
+> Requisites and document templates are typed with the same ruleset in follow-up work.

--- a/src/DTOs/Crm/CategoryDTO.php
+++ b/src/DTOs/Crm/CategoryDTO.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM product category (mirrors the JS `IProductCategory`).
+ *
+ * Nested `child_categories` are hydrated recursively.
+ */
+final class CategoryDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, CategoryDTO>  $childCategories
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?int $parentId,
+        public readonly ?string $name,
+        public readonly ?int $sort,
+        public readonly int|bool|null $isActive,
+        public readonly array $childCategories,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            parentId: $data['parent_id'] ?? null,
+            name: $data['name'] ?? null,
+            sort: $data['sort'] ?? null,
+            isActive: $data['is_active'] ?? null,
+            childCategories: array_map([self::class, 'fromArray'], $data['child_categories'] ?? []),
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/PriceTypeDTO.php
+++ b/src/DTOs/Crm/PriceTypeDTO.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM product price type (mirrors the JS `IPriceType`).
+ */
+final class PriceTypeDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly ?string $code,
+        public readonly ?int $sort,
+        public readonly ?bool $isDefault,
+        public readonly ?bool $active,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            code: $data['code'] ?? null,
+            sort: $data['sort'] ?? null,
+            isDefault: $data['default'] ?? null,
+            active: $data['active'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/ProductDTO.php
+++ b/src/DTOs/Crm/ProductDTO.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM product (mirrors the JS `IProduct`).
+ *
+ * Common fields are typed; products can also carry custom fields, so the full
+ * payload is retained in {@see $raw} and reachable via {@see get()} / {@see has()}.
+ */
+final class ProductDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, mixed>  $prices
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly ?string $type,
+        public readonly ?string $article,
+        public readonly ?bool $isActive,
+        public readonly ?string $availability,
+        public readonly ?int $productCategoryId,
+        public readonly ?int $measurementUnitId,
+        public readonly float|int|null $quantity,
+        public readonly array $prices,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            type: $data['type'] ?? null,
+            article: $data['article'] ?? null,
+            isActive: $data['is_active'] ?? null,
+            availability: $data['availability'] ?? null,
+            productCategoryId: $data['product_category_id'] ?? null,
+            measurementUnitId: $data['measurement_unit_id'] ?? null,
+            quantity: $data['quantity'] ?? null,
+            prices: $data['prices'] ?? [],
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/ProductForEntityDTO.php
+++ b/src/DTOs/Crm/ProductForEntityDTO.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A line product attached to a CRM entity (mirrors the JS `IProductForEntity`).
+ */
+final class ProductForEntityDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $title,
+        public readonly float|int|null $price,
+        public readonly ?string $currency,
+        public readonly float|int|null $quantity,
+        public readonly ?string $measurementUnitAbbr,
+        public readonly float|int|null $discountValue,
+        public readonly ?string $discountType,
+        public readonly float|int|null $amount,
+        public readonly ?int $priceTypeId,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            title: $data['title'] ?? null,
+            price: $data['price'] ?? null,
+            currency: $data['currency'] ?? null,
+            quantity: $data['quantity'] ?? null,
+            measurementUnitAbbr: $data['measurement_unit_abbr'] ?? null,
+            discountValue: $data['discount_value'] ?? null,
+            discountType: $data['discount_type'] ?? null,
+            amount: $data['amount'] ?? null,
+            priceTypeId: $data['price_type_id'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/ProductInfoForEntityDTO.php
+++ b/src/DTOs/Crm/ProductInfoForEntityDTO.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * Aggregated line-product info for a CRM entity (mirrors the JS
+ * `IProductInfoForEntity`). Nested `list_products` are hydrated.
+ */
+final class ProductInfoForEntityDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, ProductForEntityDTO>  $listProducts
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $entityType,
+        public readonly ?int $entityId,
+        public readonly float|int|null $amountTotal,
+        public readonly float|int|null $amountBeforeTax,
+        public readonly float|int|null $amountTax,
+        public readonly array $listProducts,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            entityType: $data['entity_type'] ?? null,
+            entityId: $data['entity_id'] ?? null,
+            amountTotal: $data['amount_total'] ?? null,
+            amountBeforeTax: $data['amount_before_tax'] ?? null,
+            amountTax: $data['amount_tax'] ?? null,
+            listProducts: array_map([ProductForEntityDTO::class, 'fromArray'], $data['list_products'] ?? []),
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/TaxDTO.php
+++ b/src/DTOs/Crm/TaxDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM product tax (mirrors the JS `ITax`).
+ */
+final class TaxDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly float|int|null $rate,
+        public readonly int|bool|null $isActive,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            rate: $data['rate'] ?? null,
+            isActive: $data['is_active'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/UnitDTO.php
+++ b/src/DTOs/Crm/UnitDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM product measurement unit (mirrors the JS `IMeasurementUnit`).
+ */
+final class UnitDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly ?string $abbr,
+        public readonly int|bool|null $isDefault,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            abbr: $data['abbr'] ?? null,
+            isDefault: $data['is_default'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/CrmProductsCategoryService.php
+++ b/src/Services/CrmProductsCategoryService.php
@@ -3,6 +3,7 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\CategoryDTO;
 
 /**
  * CRM product categories service.
@@ -15,18 +16,22 @@ class CrmProductsCategoryService extends Service
 
     /**
      * Get all product categories.
+     *
+     * @return array<int, CategoryDTO>
      */
-    public function getProductCategories(): Response
+    public function getProductCategories(): array
     {
-        return $this->http->get(self::NAMESPACE);
+        $data = $this->http->get(self::NAMESPACE)->json() ?? [];
+
+        return array_map([CategoryDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a product category.
      */
-    public function createProductCategory(array $data): Response
+    public function createProductCategory(array $data): CategoryDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return CategoryDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -34,9 +39,9 @@ class CrmProductsCategoryService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProductCategory($id, array $data): Response
+    public function updateProductCategory($id, array $data): CategoryDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return CategoryDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmProductsForEntityService.php
+++ b/src/Services/CrmProductsForEntityService.php
@@ -3,6 +3,8 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\ProductForEntityDTO;
+use Uspacy\SDK\DTOs\Crm\ProductInfoForEntityDTO;
 
 /**
  * CRM "products for entity" service (line products attached to CRM records).
@@ -23,12 +25,12 @@ class CrmProductsForEntityService extends Service
      * @param  string  $entityType
      * @param  int|string  $entityId
      */
-    public function getInfoProductsForEntity(string $entityType, $entityId): Response
+    public function getInfoProductsForEntity(string $entityType, $entityId): ProductInfoForEntityDTO
     {
-        return $this->http->get(self::INFO_NAMESPACE, [
+        return ProductInfoForEntityDTO::fromArray($this->http->get(self::INFO_NAMESPACE, [
             'entity_type' => $entityType,
             'entity_id' => $entityId,
-        ]);
+        ])->json() ?? []);
     }
 
     /**
@@ -36,17 +38,21 @@ class CrmProductsForEntityService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateInfoProductForEntity($id, array $info): Response
+    public function updateInfoProductForEntity($id, array $info): ProductInfoForEntityDTO
     {
-        return $this->http->patch(self::INFO_NAMESPACE . "/{$id}", $info);
+        return ProductInfoForEntityDTO::fromArray($this->http->patch(self::INFO_NAMESPACE . "/{$id}", $info)->json() ?? []);
     }
 
     /**
      * Get all line products.
+     *
+     * @return array<int, ProductForEntityDTO>
      */
-    public function getProductsForEntity(): Response
+    public function getProductsForEntity(): array
     {
-        return $this->http->get(self::NAMESPACE);
+        $data = $this->http->get(self::NAMESPACE)->json() ?? [];
+
+        return array_map([ProductForEntityDTO::class, 'fromArray'], array_filter($data, 'is_array'));
     }
 
     /**
@@ -54,17 +60,17 @@ class CrmProductsForEntityService extends Service
      *
      * @param  int|string  $id
      */
-    public function getProductForEntity($id): Response
+    public function getProductForEntity($id): ProductForEntityDTO
     {
-        return $this->http->get(self::NAMESPACE . "/{$id}");
+        return ProductForEntityDTO::fromArray($this->http->get(self::NAMESPACE . "/{$id}")->json() ?? []);
     }
 
     /**
      * Create a line product.
      */
-    public function createProductForEntity(array $data): Response
+    public function createProductForEntity(array $data): ProductInfoForEntityDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return ProductInfoForEntityDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -72,29 +78,35 @@ class CrmProductsForEntityService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProductForEntity($id, array $data): Response
+    public function updateProductForEntity($id, array $data): ProductForEntityDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return ProductForEntityDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**
      * Bulk create line products.
      *
      * @param  array  $listProducts  list of line products
+     * @return array<int, ProductForEntityDTO>
      */
-    public function createProductsForEntity(array $listProducts): Response
+    public function createProductsForEntity(array $listProducts): array
     {
-        return $this->http->post(self::NAMESPACE . '/bulk', ['list_products' => $listProducts]);
+        $data = $this->http->post(self::NAMESPACE . '/bulk', ['list_products' => $listProducts])->json() ?? [];
+
+        return array_map([ProductForEntityDTO::class, 'fromArray'], array_filter($data, 'is_array'));
     }
 
     /**
      * Bulk update line products.
      *
      * @param  array  $listProducts  list of line products
+     * @return array<int, ProductForEntityDTO>
      */
-    public function updateProductsForEntity(array $listProducts): Response
+    public function updateProductsForEntity(array $listProducts): array
     {
-        return $this->http->patch(self::NAMESPACE . '/bulk', ['list_products' => $listProducts]);
+        $data = $this->http->patch(self::NAMESPACE . '/bulk', ['list_products' => $listProducts])->json() ?? [];
+
+        return array_map([ProductForEntityDTO::class, 'fromArray'], array_filter($data, 'is_array'));
     }
 
     /**

--- a/src/Services/CrmProductsPriceTypesService.php
+++ b/src/Services/CrmProductsPriceTypesService.php
@@ -3,6 +3,7 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\PriceTypeDTO;
 
 /**
  * CRM product price types service.
@@ -15,18 +16,22 @@ class CrmProductsPriceTypesService extends Service
 
     /**
      * Get all price types.
+     *
+     * @return array<int, PriceTypeDTO>
      */
-    public function getProductPriceTypes(): Response
+    public function getProductPriceTypes(): array
     {
-        return $this->http->get(self::NAMESPACE);
+        $data = $this->http->get(self::NAMESPACE)->json() ?? [];
+
+        return array_map([PriceTypeDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a price type.
      */
-    public function createProductPriceType(array $data): Response
+    public function createProductPriceType(array $data): PriceTypeDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return PriceTypeDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -34,9 +39,9 @@ class CrmProductsPriceTypesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProductPriceType($id, array $data): Response
+    public function updateProductPriceType($id, array $data): PriceTypeDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return PriceTypeDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmProductsService.php
+++ b/src/Services/CrmProductsService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
+use Uspacy\SDK\DTOs\Crm\ProductDTO;
 
 /**
  * CRM products service.
@@ -21,18 +24,22 @@ class CrmProductsService extends Service
      * Get a page of products.
      *
      * @param  array  $params  query parameters (page, list, filters, ...)
+     * @return Collection<ProductDTO>
      */
-    public function getProducts(array $params = []): Response
+    public function getProducts(array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE, $params);
+        return Collection::fromArray(
+            $this->http->get(self::NAMESPACE, $params)->json() ?? [],
+            [ProductDTO::class, 'fromArray'],
+        );
     }
 
     /**
      * Create a product.
      */
-    public function createProduct(array $data): Response
+    public function createProduct(array $data): ProductDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return ProductDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -40,9 +47,9 @@ class CrmProductsService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProduct($id, array $data): Response
+    public function updateProduct($id, array $data): ProductDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return ProductDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -87,26 +94,30 @@ class CrmProductsService extends Service
 
     /**
      * Get product fields.
+     *
+     * @return array<int, FieldDTO>
      */
-    public function getFields(): Response
+    public function getFields(): array
     {
-        return $this->http->get(self::DYNAMIC_NAMESPACE . '/fields');
+        $data = $this->http->get(self::DYNAMIC_NAMESPACE . '/fields')->json() ?? [];
+
+        return array_map([FieldDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a product field.
      */
-    public function createField(array $data): Response
+    public function createField(array $data): FieldDTO
     {
-        return $this->http->post(self::DYNAMIC_NAMESPACE . '/fields', $data);
+        return FieldDTO::fromArray($this->http->post(self::DYNAMIC_NAMESPACE . '/fields', $data)->json() ?? []);
     }
 
     /**
      * Update a product field by its code.
      */
-    public function updateField(string $code, array $data): Response
+    public function updateField(string $code, array $data): FieldDTO
     {
-        return $this->http->patch(self::DYNAMIC_NAMESPACE . "/fields/{$code}", $data);
+        return FieldDTO::fromArray($this->http->patch(self::DYNAMIC_NAMESPACE . "/fields/{$code}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmProductsTaxesService.php
+++ b/src/Services/CrmProductsTaxesService.php
@@ -3,6 +3,7 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\TaxDTO;
 
 /**
  * CRM product taxes service.
@@ -15,18 +16,22 @@ class CrmProductsTaxesService extends Service
 
     /**
      * Get all taxes.
+     *
+     * @return array<int, TaxDTO>
      */
-    public function getProductTaxes(): Response
+    public function getProductTaxes(): array
     {
-        return $this->http->get(self::NAMESPACE);
+        $data = $this->http->get(self::NAMESPACE)->json() ?? [];
+
+        return array_map([TaxDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a tax.
      */
-    public function createProductTax(array $data): Response
+    public function createProductTax(array $data): TaxDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return TaxDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -34,9 +39,9 @@ class CrmProductsTaxesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProductTax($id, array $data): Response
+    public function updateProductTax($id, array $data): TaxDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return TaxDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmProductsUnitService.php
+++ b/src/Services/CrmProductsUnitService.php
@@ -3,6 +3,7 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Crm\UnitDTO;
 
 /**
  * CRM product measurement units service.
@@ -15,18 +16,22 @@ class CrmProductsUnitService extends Service
 
     /**
      * Get all measurement units.
+     *
+     * @return array<int, UnitDTO>
      */
-    public function getProductUnits(): Response
+    public function getProductUnits(): array
     {
-        return $this->http->get(self::NAMESPACE);
+        $data = $this->http->get(self::NAMESPACE)->json() ?? [];
+
+        return array_map([UnitDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a measurement unit.
      */
-    public function createProductUnit(array $data): Response
+    public function createProductUnit(array $data): UnitDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return UnitDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -34,9 +39,9 @@ class CrmProductsUnitService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateProductUnit($id, array $data): Response
+    public function updateProductUnit($id, array $data): UnitDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return UnitDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/tests/Services/CrmProductsDtoTest.php
+++ b/tests/Services/CrmProductsDtoTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\CategoryDTO;
+use Uspacy\SDK\DTOs\Crm\PriceTypeDTO;
+use Uspacy\SDK\DTOs\Crm\ProductDTO;
+use Uspacy\SDK\DTOs\Crm\ProductForEntityDTO;
+use Uspacy\SDK\DTOs\Crm\ProductInfoForEntityDTO;
+use Uspacy\SDK\DTOs\Crm\TaxDTO;
+use Uspacy\SDK\DTOs\Crm\UnitDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmProductsDtoTest extends TestCase
+{
+    public function test_get_products_hydrates_collection(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['id' => 1, 'title' => 'Widget', 'type' => 'goods', 'is_active' => true, 'customfield_1' => 'x'],
+            ],
+            'meta' => ['total' => 1],
+        ]);
+
+        $result = $this->sdk->crmProducts()->getProducts();
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertInstanceOf(ProductDTO::class, $result->data[0]);
+        $this->assertSame('Widget', $result->data[0]->title);
+        $this->assertTrue($result->data[0]->isActive);
+        $this->assertSame('x', $result->data[0]->get('customfield_1'));
+        $this->assertSame(1, $result->meta->total);
+    }
+
+    public function test_catalog_lists_hydrate_from_data_envelope(): void
+    {
+        $this->mockGet(['data' => [['id' => 1, 'name' => 'kg', 'abbr' => 'kg', 'is_default' => 1]]]);
+        $units = $this->sdk->crmProductsUnits()->getProductUnits();
+        $this->assertInstanceOf(UnitDTO::class, $units[0]);
+        $this->assertSame('kg', $units[0]->abbr);
+
+        $this->mockGet(['data' => [['id' => 2, 'name' => 'VAT', 'rate' => 20, 'is_active' => 1]]]);
+        $taxes = $this->sdk->crmProductsTaxes()->getProductTaxes();
+        $this->assertInstanceOf(TaxDTO::class, $taxes[0]);
+        $this->assertSame(20, $taxes[0]->rate);
+
+        $this->mockGet(['data' => [['id' => 3, 'title' => 'Retail', 'default' => true, 'active' => true]]]);
+        $priceTypes = $this->sdk->crmProductsPriceTypes()->getProductPriceTypes();
+        $this->assertInstanceOf(PriceTypeDTO::class, $priceTypes[0]);
+        $this->assertTrue($priceTypes[0]->isDefault);
+    }
+
+    public function test_categories_hydrate_nested_children(): void
+    {
+        $this->mockGet([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'Root',
+                    'parent_id' => 0,
+                    'child_categories' => [
+                        ['id' => 2, 'name' => 'Child', 'parent_id' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $categories = $this->sdk->crmProductsCategories()->getProductCategories();
+
+        $this->assertInstanceOf(CategoryDTO::class, $categories[0]);
+        $this->assertSame('Root', $categories[0]->name);
+        $this->assertInstanceOf(CategoryDTO::class, $categories[0]->childCategories[0]);
+        $this->assertSame('Child', $categories[0]->childCategories[0]->name);
+    }
+
+    public function test_products_for_entity_info_with_nested_line_products(): void
+    {
+        $this->mockGet([
+            'id' => 5,
+            'entity_type' => 'deals',
+            'entity_id' => 42,
+            'amount_total' => 300,
+            'list_products' => [
+                ['id' => 1, 'title' => 'Line A', 'price' => 100, 'quantity' => 2, 'currency' => 'UAH'],
+            ],
+        ]);
+
+        $info = $this->sdk->crmProductsForEntity()->getInfoProductsForEntity('deals', 42);
+
+        $this->assertInstanceOf(ProductInfoForEntityDTO::class, $info);
+        $this->assertSame('deals', $info->entityType);
+        $this->assertSame(300, $info->amountTotal);
+        $this->assertInstanceOf(ProductForEntityDTO::class, $info->listProducts[0]);
+        $this->assertSame('Line A', $info->listProducts[0]->title);
+        $this->assertSame(100, $info->listProducts[0]->price);
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $this->assertInstanceOf(Collection::class, $this->sdk->crmProducts()->getProducts());
+        $this->assertSame([], $this->sdk->crmProductsUnits()->getProductUnits());
+        $this->assertSame([], $this->sdk->crmProductsForEntity()->getProductsForEntity());
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the typed DTO layer for **CRM products and the product catalog**, using the approved per-pattern ruleset. Covers `CrmProductsService`, `CrmProductsCategoryService`, `CrmProductsUnitService`, `CrmProductsTaxesService`, `CrmProductsPriceTypesService` and `CrmProductsForEntityService`.

Branched off `main` (has #93/#94/#95).

## DTOs

All type their documented fields, keep the full `raw`, and support `get()` / `has()`:

- **`ProductDTO`** (`IProduct`) — products also carry custom fields.
- **`CategoryDTO`** (`IProductCategory`) — nested `childCategories` hydrated recursively.
- **`UnitDTO`**, **`TaxDTO`**, **`PriceTypeDTO`** — measurement units / taxes / price types.
- **`ProductForEntityDTO`** (`IProductForEntity`) — line products.
- **`ProductInfoForEntityDTO`** (`IProductInfoForEntity`) — nested `listProducts` hydrated.
- Product custom fields reuse the existing `FieldDTO`.

## Ruleset

| Pattern | Returns |
| --- | --- |
| `getProducts` | `Collection<ProductDTO>` |
| create/update product | `ProductDTO` |
| catalog `get…` (categories/units/taxes/price-types) | `…DTO[]` (from the `{ data }` envelope) |
| catalog create/update | matching single DTO |
| `getFields` / create-update field | `FieldDTO[]` / `FieldDTO` |
| line-product info / single / bulk | `ProductInfoForEntityDTO` / `ProductForEntityDTO` / `ProductForEntityDTO[]` |
| delete / mass / list-value ops | raw `Response` |

Hydration is null-safe (`?? []`), and **top-level list hydration also guards non-array items** (`array_filter(…, 'is_array')`) so a malformed response can't fatal.

## Docs

- Extended **`docs/crm.md`** with a products/catalog section + line-products examples + return-type table.

## Tests

**+5 tests → 139 total, 370 assertions.** New `CrmProductsDtoTest` covers product collection hydration + custom fields, catalog `DTO[]` from the data envelope, nested category children, nested line-products in the info DTO, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (139 tests, 370 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

## Follow-ups

Requisites and document templates finish CRM; then Tasks, Messenger, and the remaining services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)