### PR TITLE
Typed DTO layer: CRM requisites + document templates (completes CRM)

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -208,4 +208,58 @@ $sdk->crmProductsForEntity()->deleteProductsForEntity([1, 2]); // raw Response
 | `crmProductsForEntity()->getProductsForEntity` / `create…` / `update…` (bulk) | `ProductForEntityDTO[]` |
 | all delete / mass / list-value methods | `Saloon\Http\Response` |
 
-> Requisites and document templates are typed with the same ruleset in follow-up work.
+## Requisites
+
+`$sdk->crmRequisites()` covers card requisites, their nested bank requisites, and
+requisite templates under `/crm/v1/requisites`.
+
+```php
+// Lists -> Collection
+$sdk->crmRequisites()->getCardRequisites(['entity_id' => 5]); // Collection<RequisiteDTO>
+$sdk->crmRequisites()->getTemplates(['page' => 1]);           // Collection<RequisiteTemplateDTO>
+
+$card = $sdk->crmRequisites()->getCardRequisites()->data[0];
+$card->name;
+$card->isBasic;
+$card->templateId;
+$card->get('customfield_1');   // requisites carry custom fields too
+
+// Card requisites -> RequisiteDTO
+$sdk->crmRequisites()->createCardRequisites(['name' => 'Acme'], ['entity_id' => 5]);
+$sdk->crmRequisites()->updateCardRequisites(9, ['name' => 'Acme LLC']);
+$sdk->crmRequisites()->attachCardRequisites(['entity_id' => 5]);
+$sdk->crmRequisites()->deleteCardRequisites(9);               // raw Response
+
+// Bank requisites -> RequisiteDTO
+$sdk->crmRequisites()->createBankRequisites(9, ['iban' => 'UA...']);
+$sdk->crmRequisites()->updateBankRequisites(9, 3, ['iban' => 'UA2']);
+$sdk->crmRequisites()->attachBankRequisites(9, ['entity_id' => 5]);
+$sdk->crmRequisites()->deleteBankRequisites(9, 3);            // raw Response
+```
+
+## Document templates
+
+`$sdk->crmDocumentTemplates()` — `/crm/v1/documents/templates`.
+
+```php
+$sdk->crmDocumentTemplates()->getDocumentTemplates(['page' => 1]); // Collection<DocumentTemplateDTO>
+$sdk->crmDocumentTemplates()->getDocumentTemplatesFields();        // DocumentTemplateFieldDTO[]
+
+$sdk->crmDocumentTemplates()->createTemplate(['name' => 'Invoice']);   // DocumentTemplateDTO
+$sdk->crmDocumentTemplates()->updateTemplate(4, ['name' => 'Invoice2']); // DocumentTemplateDTO
+$sdk->crmDocumentTemplates()->deleteTemplate(4);        // raw Response
+$sdk->crmDocumentTemplates()->deleteArrayTemplates([1, 2, 3]); // raw Response
+```
+
+### Return-type reference (requisites & document templates)
+
+| Method | Returns |
+| --- | --- |
+| `crmRequisites()->getCardRequisites` | `Collection<RequisiteDTO>` |
+| `crmRequisites()->getTemplates` | `Collection<RequisiteTemplateDTO>` |
+| `crmRequisites()->create/update/attach Card/Bank Requisites` | `RequisiteDTO` |
+| `crmRequisites()->delete…` | `Saloon\Http\Response` |
+| `crmDocumentTemplates()->getDocumentTemplates` | `Collection<DocumentTemplateDTO>` |
+| `crmDocumentTemplates()->getDocumentTemplatesFields` | `DocumentTemplateFieldDTO[]` |
+| `crmDocumentTemplates()->createTemplate` / `updateTemplate` | `DocumentTemplateDTO` |
+| `crmDocumentTemplates()->deleteTemplate` / `deleteArrayTemplates` | `Saloon\Http\Response` |

--- a/src/DTOs/Crm/DocumentTemplateDTO.php
+++ b/src/DTOs/Crm/DocumentTemplateDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM document template (mirrors the JS `IDocumentTemplate`).
+ */
+final class DocumentTemplateDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly ?bool $isActive,
+        public readonly ?string $code,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            isActive: $data['is_active'] ?? null,
+            code: $data['code'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/DocumentTemplateFieldDTO.php
+++ b/src/DTOs/Crm/DocumentTemplateFieldDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A field available to CRM document templates (mirrors the JS
+ * `IDocumentTemplateField`).
+ */
+final class DocumentTemplateFieldDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly ?string $entity,
+        public readonly ?string $symbolCode,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            entity: $data['entity'] ?? null,
+            symbolCode: $data['symbol_code'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/RequisiteDTO.php
+++ b/src/DTOs/Crm/RequisiteDTO.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM requisite (card or bank; mirrors the JS `IRequisite`).
+ *
+ * Documented fields are typed; the full payload is retained in {@see $raw} and
+ * reachable via {@see get()} / {@see has()}.
+ */
+final class RequisiteDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $fields
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly ?bool $isBasic,
+        public readonly ?int $templateId,
+        public readonly ?int $sealPicture,
+        public readonly ?int $signPicture,
+        public readonly array $fields,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            isBasic: $data['is_basic'] ?? null,
+            templateId: $data['template_id'] ?? null,
+            sealPicture: $data['seal_picture'] ?? null,
+            signPicture: $data['sign_picture'] ?? null,
+            fields: $data['fields'] ?? [],
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Crm/RequisiteTemplateDTO.php
+++ b/src/DTOs/Crm/RequisiteTemplateDTO.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Crm;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A CRM requisite template (mirrors the JS `ITemplate`).
+ */
+final class RequisiteTemplateDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>|null  $region
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?int $id,
+        public readonly ?string $name,
+        public readonly ?array $region,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? null,
+            name: $data['name'] ?? null,
+            region: $data['region'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/CrmDocumentTemplatesService.php
+++ b/src/Services/CrmDocumentTemplatesService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\DocumentTemplateDTO;
+use Uspacy\SDK\DTOs\Crm\DocumentTemplateFieldDTO;
 
 /**
  * CRM document templates service.
@@ -17,28 +20,35 @@ class CrmDocumentTemplatesService extends Service
      * Get document templates.
      *
      * @param  array  $params  filter params
+     * @return Collection<DocumentTemplateDTO>
      */
-    public function getDocumentTemplates(array $params = []): Response
+    public function getDocumentTemplates(array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE, $params);
+        return Collection::fromArray(
+            $this->http->get(self::NAMESPACE, $params)->json() ?? [],
+            [DocumentTemplateDTO::class, 'fromArray'],
+        );
     }
 
     /**
      * Get the fields available for document templates.
      *
      * @param  array  $params  filter params
+     * @return array<int, DocumentTemplateFieldDTO>
      */
-    public function getDocumentTemplatesFields(array $params = []): Response
+    public function getDocumentTemplatesFields(array $params = []): array
     {
-        return $this->http->get(self::NAMESPACE . '/fields', $params);
+        $data = $this->http->get(self::NAMESPACE . '/fields', $params)->json() ?? [];
+
+        return array_map([DocumentTemplateFieldDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 
     /**
      * Create a document template.
      */
-    public function createTemplate(array $data): Response
+    public function createTemplate(array $data): DocumentTemplateDTO
     {
-        return $this->http->post(self::NAMESPACE, $data);
+        return DocumentTemplateDTO::fromArray($this->http->post(self::NAMESPACE, $data)->json() ?? []);
     }
 
     /**
@@ -46,9 +56,9 @@ class CrmDocumentTemplatesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateTemplate($id, array $data): Response
+    public function updateTemplate($id, array $data): DocumentTemplateDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return DocumentTemplateDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**

--- a/src/Services/CrmRequisitesService.php
+++ b/src/Services/CrmRequisitesService.php
@@ -3,6 +3,9 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\RequisiteDTO;
+use Uspacy\SDK\DTOs\Crm\RequisiteTemplateDTO;
 
 /**
  * CRM requisites service.
@@ -18,20 +21,28 @@ class CrmRequisitesService extends Service
      * Get requisite templates.
      *
      * @param  array  $params  pagination params (page, list)
+     * @return Collection<RequisiteTemplateDTO>
      */
-    public function getTemplates(array $params = []): Response
+    public function getTemplates(array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE . '/templates', $params);
+        return Collection::fromArray(
+            $this->http->get(self::NAMESPACE . '/templates', $params)->json() ?? [],
+            [RequisiteTemplateDTO::class, 'fromArray'],
+        );
     }
 
     /**
      * Get card requisites.
      *
      * @param  array  $params  requisite list filter params
+     * @return Collection<RequisiteDTO>
      */
-    public function getCardRequisites(array $params = []): Response
+    public function getCardRequisites(array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE, $params);
+        return Collection::fromArray(
+            $this->http->get(self::NAMESPACE, $params)->json() ?? [],
+            [RequisiteDTO::class, 'fromArray'],
+        );
     }
 
     /**
@@ -39,9 +50,9 @@ class CrmRequisitesService extends Service
      *
      * @param  array  $params  requisite list filter params
      */
-    public function createCardRequisites(array $data, array $params = []): Response
+    public function createCardRequisites(array $data, array $params = []): RequisiteDTO
     {
-        return $this->http->post(self::NAMESPACE, $data, $params);
+        return RequisiteDTO::fromArray($this->http->post(self::NAMESPACE, $data, $params)->json() ?? []);
     }
 
     /**
@@ -49,9 +60,9 @@ class CrmRequisitesService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateCardRequisites($id, array $data): Response
+    public function updateCardRequisites($id, array $data): RequisiteDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$id}", $data);
+        return RequisiteDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -59,9 +70,9 @@ class CrmRequisitesService extends Service
      *
      * @param  array  $params  requisite list filter params
      */
-    public function attachCardRequisites(array $params = []): Response
+    public function attachCardRequisites(array $params = []): RequisiteDTO
     {
-        return $this->http->post(self::NAMESPACE . '/references/attach-reference', [], $params);
+        return RequisiteDTO::fromArray($this->http->post(self::NAMESPACE . '/references/attach-reference', [], $params)->json() ?? []);
     }
 
     /**
@@ -79,9 +90,9 @@ class CrmRequisitesService extends Service
      *
      * @param  int|string  $requisiteId
      */
-    public function createBankRequisites($requisiteId, array $data): Response
+    public function createBankRequisites($requisiteId, array $data): RequisiteDTO
     {
-        return $this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites", $data);
+        return RequisiteDTO::fromArray($this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites", $data)->json() ?? []);
     }
 
     /**
@@ -90,9 +101,9 @@ class CrmRequisitesService extends Service
      * @param  int|string  $requisiteId
      * @param  int|string  $bankRequisiteId
      */
-    public function updateBankRequisites($requisiteId, $bankRequisiteId, array $data): Response
+    public function updateBankRequisites($requisiteId, $bankRequisiteId, array $data): RequisiteDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/{$requisiteId}/bank_requisites/{$bankRequisiteId}", $data);
+        return RequisiteDTO::fromArray($this->http->patch(self::NAMESPACE . "/{$requisiteId}/bank_requisites/{$bankRequisiteId}", $data)->json() ?? []);
     }
 
     /**
@@ -112,8 +123,8 @@ class CrmRequisitesService extends Service
      * @param  int|string  $requisiteId
      * @param  array  $params  requisite list filter params
      */
-    public function attachBankRequisites($requisiteId, array $params = []): Response
+    public function attachBankRequisites($requisiteId, array $params = []): RequisiteDTO
     {
-        return $this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites/references/attach-reference", [], $params);
+        return RequisiteDTO::fromArray($this->http->post(self::NAMESPACE . "/{$requisiteId}/bank_requisites/references/attach-reference", [], $params)->json() ?? []);
     }
 }

--- a/tests/Services/CrmRequisitesDtoTest.php
+++ b/tests/Services/CrmRequisitesDtoTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\DocumentTemplateDTO;
+use Uspacy\SDK\DTOs\Crm\DocumentTemplateFieldDTO;
+use Uspacy\SDK\DTOs\Crm\RequisiteDTO;
+use Uspacy\SDK\DTOs\Crm\RequisiteTemplateDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class CrmRequisitesDtoTest extends TestCase
+{
+    public function test_get_card_requisites_hydrates_collection(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['id' => 1, 'name' => 'Acme LLC', 'is_basic' => true, 'template_id' => 5, 'customfield_1' => 'x'],
+            ],
+            'meta' => ['total' => 1],
+        ]);
+
+        $result = $this->sdk->crmRequisites()->getCardRequisites(['entity_id' => 5]);
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertInstanceOf(RequisiteDTO::class, $result->data[0]);
+        $this->assertSame('Acme LLC', $result->data[0]->name);
+        $this->assertTrue($result->data[0]->isBasic);
+        $this->assertSame(5, $result->data[0]->templateId);
+        $this->assertSame('x', $result->data[0]->get('customfield_1'));
+    }
+
+    public function test_get_templates_hydrates_collection(): void
+    {
+        $this->mockGet([
+            'data' => [['id' => 1, 'name' => 'UA template', 'region' => ['code' => 'UA']]],
+            'meta' => ['total' => 1],
+        ]);
+
+        $result = $this->sdk->crmRequisites()->getTemplates(['page' => 1]);
+
+        $this->assertInstanceOf(RequisiteTemplateDTO::class, $result->data[0]);
+        $this->assertSame('UA template', $result->data[0]->name);
+        $this->assertSame(['code' => 'UA'], $result->data[0]->region);
+    }
+
+    public function test_bank_requisite_create_returns_requisite_dto(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            PostRequest::class => MockResponse::make(['id' => 9, 'name' => 'Bank', 'is_basic' => false], 201),
+        ]));
+
+        $requisite = $this->sdk->crmRequisites()->createBankRequisites(1, ['name' => 'Bank']);
+
+        $this->assertInstanceOf(RequisiteDTO::class, $requisite);
+        $this->assertSame('Bank', $requisite->name);
+    }
+
+    public function test_document_templates_and_fields(): void
+    {
+        $this->mockGet([
+            'data' => [['id' => 1, 'name' => 'Invoice', 'is_active' => true, 'code' => 'inv']],
+            'meta' => ['total' => 1],
+        ]);
+        $templates = $this->sdk->crmDocumentTemplates()->getDocumentTemplates();
+        $this->assertInstanceOf(Collection::class, $templates);
+        $this->assertInstanceOf(DocumentTemplateDTO::class, $templates->data[0]);
+        $this->assertTrue($templates->data[0]->isActive);
+
+        $this->mockGet(['data' => [['id' => 1, 'name' => 'Company name', 'entity' => 'companies', 'symbol_code' => 'company_name']]]);
+        $fields = $this->sdk->crmDocumentTemplates()->getDocumentTemplatesFields();
+        $this->assertInstanceOf(DocumentTemplateFieldDTO::class, $fields[0]);
+        $this->assertSame('company_name', $fields[0]->symbolCode);
+        $this->assertSame('companies', $fields[0]->entity);
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $this->assertInstanceOf(Collection::class, $this->sdk->crmRequisites()->getCardRequisites());
+        $this->assertSame([], $this->sdk->crmDocumentTemplates()->getDocumentTemplatesFields());
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Finishes the CRM DTO layer with **requisites and document templates**, using the approved per-pattern ruleset. Covers `CrmRequisitesService` and `CrmDocumentTemplatesService`.

With this, **all CRM services return typed DTOs.**

## DTOs

All type their documented fields, keep the full `raw`, and support `get()` / `has()`:

- **`RequisiteDTO`** (`IRequisite`) — used for both card and bank requisites (JS types both as `IRequisite`).
- **`RequisiteTemplateDTO`** (`ITemplate`).
- **`DocumentTemplateDTO`** (`IDocumentTemplate`).
- **`DocumentTemplateFieldDTO`** (`IDocumentTemplateField`).

## Ruleset

| Method | Returns |
| --- | --- |
| `getCardRequisites` | `Collection<RequisiteDTO>` |
| `getTemplates` | `Collection<RequisiteTemplateDTO>` |
| create/update/attach card & bank requisites | `RequisiteDTO` |
| `getDocumentTemplates` | `Collection<DocumentTemplateDTO>` |
| `getDocumentTemplatesFields` | `DocumentTemplateFieldDTO[]` (from the `{ data }` envelope) |
| `createTemplate` / `updateTemplate` | `DocumentTemplateDTO` |
| `deleteCardRequisites` / bank / `deleteTemplate` / `deleteArrayTemplates` | raw `Response` |

Null-safe hydration (`?? []`).

## Docs

- Extended **`docs/crm.md`** with requisites + document-templates sections and return-type tables. The CRM guide is now complete (entities, fields, funnels, stages, reasons, products, catalog, requisites, templates).

## Tests

**+5 tests → 144 total, 389 assertions.** New `CrmRequisitesDtoTest` covers card/template collection hydration + custom fields, bank-requisite `RequisiteDTO`, document templates + fields, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (144 tests, 389 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

## Status

CRM DTO coverage complete. Next: Tasks, Messenger, and the remaining platform/growth services follow the same ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)