### PR TITLE
Typed DTO layer: Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Most methods return a raw `Saloon\Http\Response`. Selected services return
 - **Auth** — `applicationSignIn()` / `refreshToken()` return a `Tokens` DTO.
 - **Users** — see the [Users service guide](docs/users.md).
 - **CRM entities** — see the [CRM service guide](docs/crm.md).
+- **Tasks** — see the [Tasks service guide](docs/tasks.md).
 
 Every output DTO keeps the **full raw payload**, so portal-specific **custom
 fields are never dropped**. Read them with `get()` / `has()`:
@@ -62,6 +63,7 @@ $user->raw;                    // the complete, untouched API payload
 
 - [Users](docs/users.md) — full DTO reference and examples.
 - [CRM entities](docs/crm.md) — entity + field DTOs, custom fields.
+- [Tasks](docs/tasks.md) — task + field DTOs, checklists, custom fields.
 
 ## Architecture
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,85 @@
+# Tasks service
+
+`$sdk->tasks()` covers the `tasks/v1` module. Task-shaped responses return a
+typed `TaskDTO` (namespace `Uspacy\SDK\DTOs\Tasks`); task fields reuse the shared
+`FieldDTO`. Every output DTO keeps the full `raw` payload, so **custom fields are
+never lost**.
+
+> `TaskDTO::id` is a **string** (task ids are strings in the API); numeric ids in
+> responses are normalised to string.
+
+```php
+use Uspacy\SDK\Http\Client\UspacySDK;
+
+$sdk = new UspacySDK('https://acme.uspacy.ua', $accessToken);
+```
+
+## Reading tasks
+
+```php
+// List -> Collection<TaskDTO>
+$page = $sdk->tasks()->getTasks(['page' => 1, 'list' => 20]);
+foreach ($page->data as $task) {
+    $task->id;                   // string
+    $task->title;
+    $task->status;
+    $task->responsibleId;
+    $task->get('customfield_1'); // custom field (or null)
+}
+$page->meta->total;
+
+// Single -> TaskDTO
+$task = $sdk->tasks()->getTask(15, ['crm_entity_list' => true]);
+
+// Templates & hierarchy -> Collection<TaskDTO>
+$sdk->tasks()->getRecurringTemplates();
+$sdk->tasks()->getOneTimeTemplates();
+$sdk->tasks()->getHierarchies();
+$sdk->tasks()->getTrashTasks();
+```
+
+## Writing tasks
+
+```php
+// Create / update / status / delegate -> TaskDTO
+$sdk->tasks()->createTask(['title' => 'Ship SDK', 'responsibleId' => 7]);
+$sdk->tasks()->patchTask(15, ['title' => 'Ship v1']);
+$sdk->tasks()->updateTask(15, ['title' => 'Ship v1']);
+$sdk->tasks()->updateTaskStatus(15, 'in_work');
+$sdk->tasks()->delegateTask(15, 42);
+$sdk->tasks()->markTaskReady(15);
+$sdk->tasks()->replicateTask(15, ['count' => 2]);
+$sdk->tasks()->createTemplate('recurring', ['title' => 'Weekly report']);
+
+// Checklists return the updated task -> TaskDTO
+$sdk->tasks()->createChecklist(15, ['name' => 'Launch']);
+$sdk->tasks()->createChecklistItem(9, ['text' => 'Write tests']);
+$sdk->tasks()->updateChecklistItem(9, 3, ['done' => true]);
+
+// Deletes, mass ops, transfers and stages return the raw Response
+$sdk->tasks()->deleteTask(15);
+$sdk->tasks()->massDeletionTasks(taskIds: ['15', '16']);
+$sdk->tasks()->transferTasksToUser(['from_user_id' => 1, 'to_user_id' => 2]);
+$sdk->tasks()->getKanbanStages(['groupId' => 3]);
+```
+
+## Fields
+
+```php
+$sdk->tasks()->getTaskFields();   // FieldDTO[] (custom_fields endpoint)
+$sdk->tasks()->getTasksFields();  // FieldDTO[] (tasks/fields endpoint)
+
+$sdk->tasks()->createTasksField(['name' => 'Priority', 'code' => 'priority']); // FieldDTO
+$sdk->tasks()->updateTasksField('priority', ['name' => 'Priority level']);     // FieldDTO
+$sdk->tasks()->deleteTasksField('priority');                                   // raw Response
+```
+
+## Return-type reference
+
+| Method | Returns |
+| --- | --- |
+| `getTasks`, `getRecurringTemplates`, `getOneTimeTemplates`, `getHierarchies`, `getTrashTasks` | `Collection<TaskDTO>` |
+| `getTask`, `getTrashTask`, `getRecurringTemplate`, `createTask`, `patchTask`, `updateTask`, `markTaskReady`, `replicateTask`, `updateTaskStatus`, `delegateTask`, `createTemplate`, `createChecklist`, `updateChecklist`, `createChecklistItem`, `updateChecklistItem` | `TaskDTO` |
+| `getTaskFields`, `getTasksFields` | `FieldDTO[]` |
+| `createTasksField`, `updateTasksField` | `FieldDTO` |
+| `deleteTask`, mass ops, transfers, kanban stages, trash restore/delete, checklist/field deletes, list-value ops | `Saloon\Http\Response` |

--- a/src/DTOs/Tasks/TaskDTO.php
+++ b/src/DTOs/Tasks/TaskDTO.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Tasks;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A task (mirrors the JS `ITask`).
+ *
+ * Common fields are typed; tasks also carry custom fields, so the full payload
+ * is retained in {@see $raw} and reachable via {@see get()} / {@see has()}.
+ * Note `id` is a string.
+ */
+final class TaskDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, mixed>  $accomplicesIds
+     * @param  array<int, mixed>  $auditorsIds
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?string $id,
+        public readonly ?string $title,
+        public readonly ?string $status,
+        public readonly ?string $priority,
+        public readonly ?string $responsibleId,
+        public readonly ?string $taskType,
+        public readonly ?string $body,
+        public readonly ?string $groupId,
+        public readonly ?string $kanbanStageId,
+        public readonly int|string|null $parentId,
+        public readonly ?int $deadline,
+        public readonly array $accomplicesIds,
+        public readonly array $auditorsIds,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: isset($data['id']) ? (string) $data['id'] : null,
+            title: $data['title'] ?? null,
+            status: $data['status'] ?? null,
+            priority: $data['priority'] ?? null,
+            responsibleId: isset($data['responsibleId']) ? (string) $data['responsibleId'] : null,
+            taskType: $data['taskType'] ?? null,
+            body: $data['body'] ?? null,
+            groupId: isset($data['groupId']) ? (string) $data['groupId'] : null,
+            kanbanStageId: isset($data['kanbanStageId']) ? (string) $data['kanbanStageId'] : null,
+            parentId: $data['parentId'] ?? null,
+            deadline: $data['deadline'] ?? null,
+            accomplicesIds: $data['accomplicesIds'] ?? [],
+            auditorsIds: $data['auditorsIds'] ?? [],
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/TasksService.php
+++ b/src/Services/TasksService.php
@@ -3,13 +3,17 @@
 namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
+use Uspacy\SDK\DTOs\Tasks\TaskDTO;
 
 /**
  * Tasks service.
  *
  * Covers the `tasks/v1` module: tasks CRUD, kanban stages, custom fields,
  * templates, transfers, trash and checklists. Mirrors the Go SDK's `tasks.go`
- * and the JS SDK's TasksService.
+ * and the JS SDK's TasksService. Task-shaped responses return {@see TaskDTO};
+ * task fields reuse {@see FieldDTO} (the shared `IField` model).
  */
 class TasksService extends Service
 {
@@ -27,18 +31,19 @@ class TasksService extends Service
      * Get a page of tasks.
      *
      * @param  array  $params  query parameters (page, list, filters, ...)
+     * @return Collection<TaskDTO>
      */
-    public function getTasks(array $params = []): Response
+    public function getTasks(array $params = []): Collection
     {
-        return $this->http->get(self::NAMESPACE . '/tasks', $params);
+        return $this->toTaskCollection($this->http->get(self::NAMESPACE . '/tasks', $params));
     }
 
     /**
      * Create a task.
      */
-    public function createTask(array $data): Response
+    public function createTask(array $data): TaskDTO
     {
-        return $this->http->post(self::NAMESPACE . '/tasks', $data);
+        return $this->toTask($this->http->post(self::NAMESPACE . '/tasks', $data));
     }
 
     /**
@@ -46,9 +51,9 @@ class TasksService extends Service
      *
      * @param  int|string  $taskId
      */
-    public function patchTask($taskId, array $data): Response
+    public function patchTask($taskId, array $data): TaskDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/tasks/{$taskId}", $data);
+        return $this->toTask($this->http->patch(self::NAMESPACE . "/tasks/{$taskId}", $data));
     }
 
     /**
@@ -56,9 +61,9 @@ class TasksService extends Service
      *
      * @param  int|string  $taskId
      */
-    public function markTaskReady($taskId): Response
+    public function markTaskReady($taskId): TaskDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/tasks/{$taskId}/ready");
+        return $this->toTask($this->http->patch(self::NAMESPACE . "/tasks/{$taskId}/ready"));
     }
 
     /**
@@ -71,10 +76,12 @@ class TasksService extends Service
 
     /**
      * Get the custom fields available for tasks.
+     *
+     * @return array<int, FieldDTO>
      */
-    public function getTaskFields(): Response
+    public function getTaskFields(): array
     {
-        return $this->http->get(self::NAMESPACE . '/custom_fields/tasks/fields');
+        return $this->toFields($this->http->get(self::NAMESPACE . '/custom_fields/tasks/fields'));
     }
 
     /**
@@ -110,9 +117,9 @@ class TasksService extends Service
      *
      * @param  int|string  $templateId
      */
-    public function getRecurringTemplate($templateId): Response
+    public function getRecurringTemplate($templateId): TaskDTO
     {
-        return $this->http->get(self::NAMESPACE . "/templates/recurring/{$templateId}");
+        return $this->toTask($this->http->get(self::NAMESPACE . "/templates/recurring/{$templateId}"));
     }
 
     /**
@@ -121,9 +128,9 @@ class TasksService extends Service
      * @param  int|string  $id
      * @param  array  $params  extra query params (e.g. crm_entity_list)
      */
-    public function getTask($id, array $params = []): Response
+    public function getTask($id, array $params = []): TaskDTO
     {
-        return $this->http->get(self::TASKS . "/{$id}/", $params);
+        return $this->toTask($this->http->get(self::TASKS . "/{$id}/", $params));
     }
 
     /**
@@ -131,9 +138,9 @@ class TasksService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateTask($id, array $data): Response
+    public function updateTask($id, array $data): TaskDTO
     {
-        return $this->http->patch(self::TASKS . "/{$id}/", $data);
+        return $this->toTask($this->http->patch(self::TASKS . "/{$id}/", $data));
     }
 
     /**
@@ -151,9 +158,9 @@ class TasksService extends Service
      *
      * @param  int|string  $id
      */
-    public function replicateTask($id, array $data): Response
+    public function replicateTask($id, array $data): TaskDTO
     {
-        return $this->http->post(self::TASKS . "/{$id}/replicate", $data);
+        return $this->toTask($this->http->post(self::TASKS . "/{$id}/replicate", $data));
     }
 
     /**
@@ -161,9 +168,9 @@ class TasksService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateTaskStatus($id, string $action): Response
+    public function updateTaskStatus($id, string $action): TaskDTO
     {
-        return $this->http->patch(self::TASKS . "/{$id}/{$action}");
+        return $this->toTask($this->http->patch(self::TASKS . "/{$id}/{$action}"));
     }
 
     /**
@@ -172,9 +179,9 @@ class TasksService extends Service
      * @param  int|string  $id
      * @param  int|string  $userId
      */
-    public function delegateTask($id, $userId): Response
+    public function delegateTask($id, $userId): TaskDTO
     {
-        return $this->http->patch(self::TASKS . "/{$id}/delegation", ['user_id' => $userId]);
+        return $this->toTask($this->http->patch(self::TASKS . "/{$id}/delegation", ['user_id' => $userId]));
     }
 
     /**
@@ -228,58 +235,66 @@ class TasksService extends Service
 
     /**
      * Get recurring task templates.
+     *
+     * @return Collection<TaskDTO>
      */
-    public function getRecurringTemplates(array $params = []): Response
+    public function getRecurringTemplates(array $params = []): Collection
     {
-        return $this->http->get(self::TEMPLATES . '/recurring', $params);
+        return $this->toTaskCollection($this->http->get(self::TEMPLATES . '/recurring', $params));
     }
 
     /**
      * Get one-time task templates.
+     *
+     * @return Collection<TaskDTO>
      */
-    public function getOneTimeTemplates(array $params = []): Response
+    public function getOneTimeTemplates(array $params = []): Collection
     {
-        return $this->http->get(self::TEMPLATES . '/one_time', $params);
+        return $this->toTaskCollection($this->http->get(self::TEMPLATES . '/one_time', $params));
     }
 
     /**
      * Create a task template of the given type (recurring / one_time).
      */
-    public function createTemplate(string $type, array $data): Response
+    public function createTemplate(string $type, array $data): TaskDTO
     {
-        return $this->http->post(self::TEMPLATES . "/{$type}", $data);
+        return $this->toTask($this->http->post(self::TEMPLATES . "/{$type}", $data));
     }
 
     /**
      * Get the task hierarchy.
+     *
+     * @return Collection<TaskDTO>
      */
-    public function getHierarchies(array $params = []): Response
+    public function getHierarchies(array $params = []): Collection
     {
-        return $this->http->get(self::TASKS . '/hierarchy', $params);
+        return $this->toTaskCollection($this->http->get(self::TASKS . '/hierarchy', $params));
     }
 
     /**
      * Get task fields (JS-parity endpoint at `tasks/fields`).
+     *
+     * @return array<int, FieldDTO>
      */
-    public function getTasksFields(): Response
+    public function getTasksFields(): array
     {
-        return $this->http->get(self::TASKS . '/fields');
+        return $this->toFields($this->http->get(self::TASKS . '/fields'));
     }
 
     /**
      * Create a task field.
      */
-    public function createTasksField(array $data): Response
+    public function createTasksField(array $data): FieldDTO
     {
-        return $this->http->post(self::TASKS . '/fields', $data);
+        return FieldDTO::fromArray($this->http->post(self::TASKS . '/fields', $data)->json() ?? []);
     }
 
     /**
      * Update a task field by code.
      */
-    public function updateTasksField(string $fieldCode, array $data): Response
+    public function updateTasksField(string $fieldCode, array $data): FieldDTO
     {
-        return $this->http->patch(self::TASKS . "/fields/{$fieldCode}", $data);
+        return FieldDTO::fromArray($this->http->patch(self::TASKS . "/fields/{$fieldCode}", $data)->json() ?? []);
     }
 
     /**
@@ -340,10 +355,12 @@ class TasksService extends Service
 
     /**
      * Get deleted (trash) tasks.
+     *
+     * @return Collection<TaskDTO>
      */
-    public function getTrashTasks(array $params = []): Response
+    public function getTrashTasks(array $params = []): Collection
     {
-        return $this->http->get(self::TRASH, $params);
+        return $this->toTaskCollection($this->http->get(self::TRASH, $params));
     }
 
     /**
@@ -351,9 +368,9 @@ class TasksService extends Service
      *
      * @param  int|string  $id
      */
-    public function getTrashTask($id): Response
+    public function getTrashTask($id): TaskDTO
     {
-        return $this->http->get(self::TRASH, ['id' => $id]);
+        return $this->toTask($this->http->get(self::TRASH, ['id' => $id]));
     }
 
     /**
@@ -391,23 +408,23 @@ class TasksService extends Service
     }
 
     /**
-     * Create a checklist on a task.
+     * Create a checklist on a task. Returns the updated task.
      *
      * @param  int|string  $taskId
      */
-    public function createChecklist($taskId, array $data): Response
+    public function createChecklist($taskId, array $data): TaskDTO
     {
-        return $this->http->post(self::TASKS . "/{$taskId}/checklists/", $data);
+        return $this->toTask($this->http->post(self::TASKS . "/{$taskId}/checklists/", $data));
     }
 
     /**
-     * Update a checklist.
+     * Update a checklist. Returns the updated task.
      *
      * @param  int|string  $id
      */
-    public function updateChecklist($id, array $data): Response
+    public function updateChecklist($id, array $data): TaskDTO
     {
-        return $this->http->patch(self::TASKS . "/checklists/{$id}", $data);
+        return $this->toTask($this->http->patch(self::TASKS . "/checklists/{$id}", $data));
     }
 
     /**
@@ -421,24 +438,24 @@ class TasksService extends Service
     }
 
     /**
-     * Create a checklist item.
+     * Create a checklist item. Returns the updated task.
      *
      * @param  int|string  $id  checklist id
      */
-    public function createChecklistItem($id, array $data): Response
+    public function createChecklistItem($id, array $data): TaskDTO
     {
-        return $this->http->post(self::TASKS . "/checklists/{$id}/items", $data);
+        return $this->toTask($this->http->post(self::TASKS . "/checklists/{$id}/items", $data));
     }
 
     /**
-     * Update a checklist item.
+     * Update a checklist item. Returns the updated task.
      *
      * @param  int|string  $id  checklist id
      * @param  int|string  $itemId
      */
-    public function updateChecklistItem($id, $itemId, array $data): Response
+    public function updateChecklistItem($id, $itemId, array $data): TaskDTO
     {
-        return $this->http->patch(self::TASKS . "/checklists/{$id}/items/{$itemId}", $data);
+        return $this->toTask($this->http->patch(self::TASKS . "/checklists/{$id}/items/{$itemId}", $data));
     }
 
     /**
@@ -450,5 +467,28 @@ class TasksService extends Service
     public function deleteChecklistItem($id, $itemId): Response
     {
         return $this->http->delete(self::TASKS . "/checklists/{$id}/items/{$itemId}");
+    }
+
+    private function toTask(Response $response): TaskDTO
+    {
+        return TaskDTO::fromArray($response->json() ?? []);
+    }
+
+    /**
+     * @return Collection<TaskDTO>
+     */
+    private function toTaskCollection(Response $response): Collection
+    {
+        return Collection::fromArray($response->json() ?? [], [TaskDTO::class, 'fromArray']);
+    }
+
+    /**
+     * @return array<int, FieldDTO>
+     */
+    private function toFields(Response $response): array
+    {
+        $data = $response->json() ?? [];
+
+        return array_map([FieldDTO::class, 'fromArray'], $data['data'] ?? []);
     }
 }

--- a/tests/Services/TasksDtoTest.php
+++ b/tests/Services/TasksDtoTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Collection;
+use Uspacy\SDK\DTOs\Crm\FieldDTO;
+use Uspacy\SDK\DTOs\Tasks\TaskDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PatchRequest;
+use Uspacy\SDK\Http\Client\Requests\PostRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class TasksDtoTest extends TestCase
+{
+    public function test_get_tasks_hydrates_collection(): void
+    {
+        $this->mockGet([
+            'data' => [
+                ['id' => '10', 'title' => 'Ship', 'status' => 'in_work', 'priority' => 'high', 'customfield_1' => 'x'],
+            ],
+            'meta' => ['total' => 1, 'page' => 1],
+        ]);
+
+        $result = $this->sdk->tasks()->getTasks(['page' => 1]);
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertInstanceOf(TaskDTO::class, $result->data[0]);
+        $this->assertSame('10', $result->data[0]->id);
+        $this->assertSame('in_work', $result->data[0]->status);
+        $this->assertSame('x', $result->data[0]->get('customfield_1'));
+        $this->assertSame(1, $result->meta->total);
+    }
+
+    public function test_id_is_normalised_to_string(): void
+    {
+        // API may return a numeric id; the DTO exposes it as string.
+        $this->mockGet(['id' => 42, 'title' => 'T', 'responsibleId' => 7, 'groupId' => 3]);
+
+        $task = $this->sdk->tasks()->getTask(42);
+
+        $this->assertSame('42', $task->id);
+        $this->assertSame('7', $task->responsibleId);
+        $this->assertSame('3', $task->groupId);
+    }
+
+    public function test_status_and_delegation_return_task_dto(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            PatchRequest::class => MockResponse::make(['id' => '5', 'status' => 'in_work'], 200),
+        ]));
+
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->updateTaskStatus(5, 'in_work'));
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->delegateTask(5, 7));
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->markTaskReady(5));
+    }
+
+    public function test_checklist_ops_return_the_task(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            PostRequest::class => MockResponse::make(['id' => '5', 'title' => 'T'], 201),
+            PatchRequest::class => MockResponse::make(['id' => '5', 'title' => 'T'], 200),
+        ]));
+
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->createChecklist(5, ['name' => 'C']));
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->createChecklistItem(9, ['text' => 'do']));
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->updateChecklistItem(9, 3, ['done' => true]));
+    }
+
+    public function test_task_fields_hydrate_field_dtos_from_data_envelope(): void
+    {
+        $this->mockGet(['data' => [['name' => 'Priority', 'code' => 'priority', 'type' => 'list']]]);
+
+        $fields = $this->sdk->tasks()->getTasksFields();
+
+        $this->assertInstanceOf(FieldDTO::class, $fields[0]);
+        $this->assertSame('priority', $fields[0]->code);
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $this->assertInstanceOf(Collection::class, $this->sdk->tasks()->getTasks());
+        $this->assertInstanceOf(TaskDTO::class, $this->sdk->tasks()->getTask(1));
+        $this->assertSame([], $this->sdk->tasks()->getTasksFields());
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the typed DTO layer for **Tasks** (`TasksService`, 43 methods), using the approved per-pattern ruleset.

## DTO

- **`TaskDTO`** (`ITask`) — common fields typed (title, status, priority, responsibleId, deadline, taskType, groupId, kanbanStageId, …), full `raw` retained, `get()`/`has()` for custom fields. **`id` is a string** (task ids are strings; numeric ids are normalised).
- Task fields reuse the shared **`FieldDTO`** (same `IField` model), rather than duplicating it.

## Ruleset

| Pattern | Returns |
| --- | --- |
| `getTasks`, templates, hierarchy, trash list | `Collection<TaskDTO>` |
| get / create / update / patch / status / delegate / replicate / markReady / createTemplate | `TaskDTO` |
| checklist create/update (JS returns the task) | `TaskDTO` |
| `getTaskFields` / `getTasksFields` | `FieldDTO[]` (from the `{ data }` envelope) |
| create/update task field | `FieldDTO` |
| deletes, mass ops, transfers, kanban stages, trash restore/delete, list-value ops | raw `Response` |

Hydration is null-safe (`?? []`) via small private helpers (`toTask` / `toTaskCollection` / `toFields`).

> Task kanban stages (`getKanbanStages`/`createStage`/`deleteStage`) are left as raw `Response` for now — they use a distinct stage model and can be typed in a focused follow-up (as CRM stages were).

## Docs

- New **`docs/tasks.md`** service guide (return-type table, checklists, custom fields), linked from the README.

## Tests

**+6 tests → 145 total, 390 assertions.** New `TasksDtoTest` covers collection hydration + custom fields, string-id normalisation, status/delegation/checklist ops returning `TaskDTO`, task fields, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (145 tests, 390 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)