### PR TITLE
Typed DTO layer: Messenger (quick answers, chats, settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Most methods return a raw `Saloon\Http\Response`. Selected services return
 - **Users** — see the [Users service guide](docs/users.md).
 - **CRM entities** — see the [CRM service guide](docs/crm.md).
 - **Tasks** — see the [Tasks service guide](docs/tasks.md).
+- **Messenger** (partial) — see the [Messenger service guide](docs/messenger.md).
 
 Every output DTO keeps the **full raw payload**, so portal-specific **custom
 fields are never dropped**. Read them with `get()` / `has()`:
@@ -64,6 +65,7 @@ $user->raw;                    // the complete, untouched API payload
 - [Users](docs/users.md) — full DTO reference and examples.
 - [CRM entities](docs/crm.md) — entity + field DTOs, custom fields.
 - [Tasks](docs/tasks.md) — task + field DTOs, checklists, custom fields.
+- [Messenger](docs/messenger.md) — quick answers, chats, settings (partial).
 
 ## Architecture
 

--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -1,0 +1,55 @@
+# Messenger service
+
+`$sdk->messenger()` covers the `messenger/v1` module. A **subset** of methods with
+clean, well-defined shapes return typed DTOs (namespace `Uspacy\SDK\DTOs\Messenger`);
+the rest — messages, external lines, widgets, chat relations — return the raw
+`Saloon\Http\Response` (their payloads are heterogeneous / bespoke). Every output
+DTO keeps the full `raw` payload.
+
+```php
+use Uspacy\SDK\Http\Client\UspacySDK;
+
+$sdk = new UspacySDK('https://acme.uspacy.ua', $accessToken);
+```
+
+## Chats
+
+```php
+// -> ChatDTO[]
+$chats = $sdk->messenger()->getChats(['status' => 'active']);
+$chats[0]->id;        // string
+$chats[0]->name;
+$chats[0]->type;
+$chats[0]->members;
+$chats[0]->get('lastMessage'); // full payload available via get()/raw
+```
+
+## Quick answers (quick replies)
+
+```php
+$sdk->messenger()->getQuickAnswers(['status' => 'active']);   // QuickAnswerDTO[]
+$sdk->messenger()->getQuickAnswerById('q1');                  // QuickAnswerDTO
+
+$sdk->messenger()->createQuickAnswer(['name' => 'Greeting', 'message' => 'Hi!']);  // QuickAnswerDTO
+$sdk->messenger()->updateQuickAnswer('q1', ['message' => 'Hello!']);               // QuickAnswerDTO
+$sdk->messenger()->updateQuickAnswerStatus('q1', 'inactive');                      // QuickAnswerDTO
+$sdk->messenger()->deleteQuickAnswer('q1');                                        // raw Response
+```
+
+## User settings
+
+```php
+$settings = $sdk->messenger()->getSettings();                 // UserSettingsDTO
+$settings->isInternalMsgSoundEnabled;
+$sdk->messenger()->updateSettings(['isInternalMsgSoundEnabled' => false]); // UserSettingsDTO
+```
+
+## Return-type reference
+
+| Method | Returns |
+| --- | --- |
+| `getChats` | `ChatDTO[]` |
+| `getQuickAnswers` | `QuickAnswerDTO[]` |
+| `getQuickAnswerById`, `createQuickAnswer`, `updateQuickAnswer`, `updateQuickAnswerStatus` | `QuickAnswerDTO` |
+| `getSettings`, `updateSettings` | `UserSettingsDTO` |
+| everything else (messages, external lines, widgets, relations, pinned, read-all, …) | `Saloon\Http\Response` |

--- a/src/DTOs/Messenger/ChatDTO.php
+++ b/src/DTOs/Messenger/ChatDTO.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Messenger;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A messenger chat (mirrors the JS `IChat`).
+ *
+ * Documented fields are typed; the full payload (including `lastMessage`) is
+ * retained in {@see $raw}.
+ */
+final class ChatDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, mixed>  $members
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?string $id,
+        public readonly ?string $name,
+        public readonly ?string $type,
+        public readonly ?int $ownerId,
+        public readonly ?int $groupId,
+        public readonly ?int $timestamp,
+        public readonly ?bool $pinned,
+        public readonly array $members,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: isset($data['id']) ? (string) $data['id'] : null,
+            name: $data['name'] ?? null,
+            type: $data['type'] ?? null,
+            ownerId: $data['ownerId'] ?? null,
+            groupId: $data['groupId'] ?? null,
+            timestamp: $data['timestamp'] ?? null,
+            pinned: $data['pinned'] ?? null,
+            members: $data['members'] ?? [],
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Messenger/QuickAnswerDTO.php
+++ b/src/DTOs/Messenger/QuickAnswerDTO.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Messenger;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * A messenger quick answer / quick reply (mirrors the JS `IQuickAnswer`).
+ */
+final class QuickAnswerDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<int, mixed>  $availableForUsers
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?string $id,
+        public readonly ?string $name,
+        public readonly ?string $message,
+        public readonly ?string $status,
+        public readonly ?int $ownerId,
+        public readonly array $availableForUsers,
+        public readonly ?int $createdAt,
+        public readonly ?int $updatedAt,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: isset($data['id']) ? (string) $data['id'] : null,
+            name: $data['name'] ?? null,
+            message: $data['message'] ?? null,
+            status: $data['status'] ?? null,
+            ownerId: $data['ownerId'] ?? null,
+            availableForUsers: $data['availableForUsers'] ?? [],
+            createdAt: $data['createdAt'] ?? null,
+            updatedAt: $data['updatedAt'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/DTOs/Messenger/UserSettingsDTO.php
+++ b/src/DTOs/Messenger/UserSettingsDTO.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Uspacy\SDK\DTOs\Messenger;
+
+use Uspacy\SDK\DTOs\Concerns\HasRawData;
+
+/**
+ * Messenger user settings (mirrors the JS `IUserSettings`).
+ */
+final class UserSettingsDTO
+{
+    use HasRawData;
+
+    /**
+     * @param  array<string, mixed>  $raw
+     */
+    public function __construct(
+        public readonly ?string $id,
+        public readonly ?int $authUserId,
+        public readonly ?bool $isInternalMsgSoundEnabled,
+        public readonly ?bool $isExternalMsgSoundEnabled,
+        public readonly array $raw,
+    ) {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: isset($data['id']) ? (string) $data['id'] : null,
+            authUserId: $data['authUserId'] ?? null,
+            isInternalMsgSoundEnabled: $data['isInternalMsgSoundEnabled'] ?? null,
+            isExternalMsgSoundEnabled: $data['isExternalMsgSoundEnabled'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/Services/MessengerService.php
+++ b/src/Services/MessengerService.php
@@ -4,6 +4,9 @@ namespace Uspacy\SDK\Services;
 
 use Saloon\Http\Response;
 use Uspacy\SDK\DTOs\Messages\UpdateMessageStatusDTO;
+use Uspacy\SDK\DTOs\Messenger\ChatDTO;
+use Uspacy\SDK\DTOs\Messenger\QuickAnswerDTO;
+use Uspacy\SDK\DTOs\Messenger\UserSettingsDTO;
 use Uspacy\SDK\Http\Client\Requests\Messenger\CreateChatRequest;
 use Uspacy\SDK\Http\Client\Requests\Messenger\CreateExternalLineRequest;
 use Uspacy\SDK\Http\Client\Requests\Messenger\CreateMessageRequest;
@@ -85,10 +88,13 @@ class MessengerService extends Service
      * Get chats.
      *
      * @param  array  $params  chat fetch params (status, type, ...)
+     * @return array<int, ChatDTO>
      */
-    public function getChats(array $params = []): Response
+    public function getChats(array $params = []): array
     {
-        return $this->http->get(self::NAMESPACE . '/chats', $params);
+        $data = $this->http->get(self::NAMESPACE . '/chats', $params)->json() ?? [];
+
+        return array_map([ChatDTO::class, 'fromArray'], array_filter($data, 'is_array'));
     }
 
     /**
@@ -171,10 +177,13 @@ class MessengerService extends Service
      * Get quick answers (quick replies).
      *
      * @param  array  $params  filter params
+     * @return array<int, QuickAnswerDTO>
      */
-    public function getQuickAnswers(array $params = []): Response
+    public function getQuickAnswers(array $params = []): array
     {
-        return $this->http->get(self::NAMESPACE . '/quick-replies', $params);
+        $data = $this->http->get(self::NAMESPACE . '/quick-replies', $params)->json() ?? [];
+
+        return array_map([QuickAnswerDTO::class, 'fromArray'], array_filter($data, 'is_array'));
     }
 
     /**
@@ -182,17 +191,17 @@ class MessengerService extends Service
      *
      * @param  int|string  $id
      */
-    public function getQuickAnswerById($id): Response
+    public function getQuickAnswerById($id): QuickAnswerDTO
     {
-        return $this->http->get(self::NAMESPACE . "/quick-replies/{$id}");
+        return QuickAnswerDTO::fromArray($this->http->get(self::NAMESPACE . "/quick-replies/{$id}")->json() ?? []);
     }
 
     /**
      * Create a quick answer.
      */
-    public function createQuickAnswer(array $data): Response
+    public function createQuickAnswer(array $data): QuickAnswerDTO
     {
-        return $this->http->post(self::NAMESPACE . '/quick-replies', $data);
+        return QuickAnswerDTO::fromArray($this->http->post(self::NAMESPACE . '/quick-replies', $data)->json() ?? []);
     }
 
     /**
@@ -200,9 +209,9 @@ class MessengerService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateQuickAnswer($id, array $data): Response
+    public function updateQuickAnswer($id, array $data): QuickAnswerDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/quick-replies/{$id}", $data);
+        return QuickAnswerDTO::fromArray($this->http->patch(self::NAMESPACE . "/quick-replies/{$id}", $data)->json() ?? []);
     }
 
     /**
@@ -210,9 +219,9 @@ class MessengerService extends Service
      *
      * @param  int|string  $id
      */
-    public function updateQuickAnswerStatus($id, string $status): Response
+    public function updateQuickAnswerStatus($id, string $status): QuickAnswerDTO
     {
-        return $this->http->patch(self::NAMESPACE . "/quick-replies/{$id}/status/{$status}");
+        return QuickAnswerDTO::fromArray($this->http->patch(self::NAMESPACE . "/quick-replies/{$id}/status/{$status}")->json() ?? []);
     }
 
     /**
@@ -287,16 +296,16 @@ class MessengerService extends Service
     /**
      * Get the current user's messenger settings.
      */
-    public function getSettings(): Response
+    public function getSettings(): UserSettingsDTO
     {
-        return $this->http->get(self::NAMESPACE . '/user-settings');
+        return UserSettingsDTO::fromArray($this->http->get(self::NAMESPACE . '/user-settings')->json() ?? []);
     }
 
     /**
      * Update the current user's messenger settings.
      */
-    public function updateSettings(array $settings): Response
+    public function updateSettings(array $settings): UserSettingsDTO
     {
-        return $this->http->patch(self::NAMESPACE . '/user-settings', $settings);
+        return UserSettingsDTO::fromArray($this->http->patch(self::NAMESPACE . '/user-settings', $settings)->json() ?? []);
     }
 }

--- a/tests/Services/MessengerDtoTest.php
+++ b/tests/Services/MessengerDtoTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Uspacy\SDK\Tests\Services;
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Uspacy\SDK\DTOs\Messenger\ChatDTO;
+use Uspacy\SDK\DTOs\Messenger\QuickAnswerDTO;
+use Uspacy\SDK\DTOs\Messenger\UserSettingsDTO;
+use Uspacy\SDK\Http\Client\Requests\GetRequest;
+use Uspacy\SDK\Http\Client\Requests\PatchRequest;
+use Uspacy\SDK\Tests\TestCase;
+
+class MessengerDtoTest extends TestCase
+{
+    public function test_get_chats_hydrates_chat_dtos(): void
+    {
+        $this->mockGet([
+            ['id' => 'c1', 'name' => 'General', 'type' => 'INTERNAL', 'members' => [1, 2], 'pinned' => true],
+            ['id' => 'c2', 'name' => 'Support', 'type' => 'EXTERNAL', 'members' => [3]],
+        ]);
+
+        $chats = $this->sdk->messenger()->getChats(['status' => 'active']);
+
+        $this->assertCount(2, $chats);
+        $this->assertInstanceOf(ChatDTO::class, $chats[0]);
+        $this->assertSame('General', $chats[0]->name);
+        $this->assertTrue($chats[0]->pinned);
+        $this->assertSame([1, 2], $chats[0]->members);
+    }
+
+    public function test_quick_answers_hydrate(): void
+    {
+        $this->mockGet(['id' => 'q1', 'name' => 'Greeting', 'message' => 'Hi!', 'status' => 'active', 'ownerId' => 7]);
+
+        $answer = $this->sdk->messenger()->getQuickAnswerById('q1');
+
+        $this->assertInstanceOf(QuickAnswerDTO::class, $answer);
+        $this->assertSame('Greeting', $answer->name);
+        $this->assertSame('Hi!', $answer->message);
+        $this->assertSame(7, $answer->ownerId);
+    }
+
+    public function test_update_quick_answer_status_returns_dto(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            PatchRequest::class => MockResponse::make(['id' => 'q1', 'status' => 'inactive'], 200),
+        ]));
+
+        $answer = $this->sdk->messenger()->updateQuickAnswerStatus('q1', 'inactive');
+
+        $this->assertInstanceOf(QuickAnswerDTO::class, $answer);
+        $this->assertSame('inactive', $answer->status);
+    }
+
+    public function test_settings_hydrate(): void
+    {
+        $this->mockGet([
+            'id' => 's1',
+            'authUserId' => 7,
+            'isInternalMsgSoundEnabled' => true,
+            'isExternalMsgSoundEnabled' => false,
+        ]);
+
+        $settings = $this->sdk->messenger()->getSettings();
+
+        $this->assertInstanceOf(UserSettingsDTO::class, $settings);
+        $this->assertTrue($settings->isInternalMsgSoundEnabled);
+        $this->assertFalse($settings->isExternalMsgSoundEnabled);
+        $this->assertSame(7, $settings->authUserId);
+    }
+
+    public function test_empty_body_does_not_throw(): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make('', 204),
+        ]));
+
+        $this->assertSame([], $this->sdk->messenger()->getChats());
+        $this->assertSame([], $this->sdk->messenger()->getQuickAnswers());
+        $this->assertInstanceOf(UserSettingsDTO::class, $this->sdk->messenger()->getSettings());
+    }
+
+    private function mockGet(array $payload): void
+    {
+        $this->sdk->withMockClient(new MockClient([
+            GetRequest::class => MockResponse::make($payload, 200),
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the typed DTO layer for **Messenger**, typing the **cleanly-shaped subset** of `MessengerService`. The heterogeneous/bespoke methods (messages, external lines, widgets, chat relations) intentionally stay as raw `Response`.

## Why partial

Messenger is far less uniform than CRM/Tasks: message and external-line ops go through dedicated request classes with bespoke behaviour, widgets/relations have niche shapes, and cursor-paginated chats use a distinct envelope. Rather than force half-fitting DTOs, I typed the three areas with clear, stable shapes and left the rest returning `Response` (documented).

## DTOs

- **`QuickAnswerDTO`** (`IQuickAnswer`)
- **`ChatDTO`** (`IChat`) — `lastMessage` etc. available via `get()`/`raw`
- **`UserSettingsDTO`** (`IUserSettings`)

## Ruleset

| Method | Returns |
| --- | --- |
| `getChats` | `ChatDTO[]` |
| `getQuickAnswers` | `QuickAnswerDTO[]` |
| `getQuickAnswerById`, `createQuickAnswer`, `updateQuickAnswer`, `updateQuickAnswerStatus` | `QuickAnswerDTO` |
| `getSettings`, `updateSettings` | `UserSettingsDTO` |
| everything else (messages, external lines, widgets, relations, pinned, read-all, …) | raw `Response` |

Hydration is null-safe (`?? []`); top-level lists guard non-array items (`array_filter(…, 'is_array')`).

## Docs

- New **`docs/messenger.md`** (clearly marks the typed subset), linked from the README.

## Tests

**+5 tests → 155 total, 427 assertions.** New `MessengerDtoTest` covers chats, quick answers (incl. status update), settings, and empty-body null-safety.

## Verification

- ✅ `composer test` → OK (155 tests, 427 assertions)
- ✅ `composer check-cs` (ECS) → clean
- ✅ `composer validate --strict` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)